### PR TITLE
more replacements of xquery with avax

### DIFF
--- a/autobuild/app.py
+++ b/autobuild/app.py
@@ -146,8 +146,8 @@ def processcustom(customlist):
                                 used_ip[f'{k.lower()}_ip'] = custom_ip
                                 break
                 if name.upper() == 'AVAX':
-                    customlist[0]['deploy_xquery'] = True
-                    customlist[0]['plugins'].append('xquery')
+                    customlist[0]['deploy_avax'] = True
+                    customlist[0]['plugins'].append('avax')
                 #volumes paths configs
                 for j in list(c['daemons'][i]):
                     if j not in ['name','image']:

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -71,9 +71,9 @@ services:
         ipv4_address: {{ testsnode_ip }}
 {% endif %}
 
-{% if deploy_xquery %}
-  xquery:
-    image: {{ xquery_image }}
+{% if deploy_avax %}
+  avax:
+    image: {{ avax_image }}
     restart: unless-stopped
     expose:
       - 9650
@@ -84,7 +84,7 @@ services:
       - --index-enabled
       - --db-dir=/data
     volumes:
-      - {{ xquery_data_mount_dir }}/XQUERY:/data
+      - {{ avax_data_mount_dir }}/AVAX:/data
     logging:
       driver: "json-file"
       options:
@@ -92,7 +92,7 @@ services:
         max-file: "10"
     networks:
       backend:
-        ipv4_address: {{ xquery_ip }}
+        ipv4_address: {{ avax_ip }}
 {% endif %}
 
 {% if deploy_eth %}
@@ -198,8 +198,8 @@ services:
       DB_PASSWORD: password
       DB_DATABASE: eth
 {% endif %}
-{% if deploy_xquery %}
-      XQUERY_HOST: http://{{ xquery_ip }}:9650
+{% if deploy_avax %}
+      XQUERY_HOST: http://{{ avax_ip }}:9650
 {% endif %}
     volumes:
       - {{ xr_proxy_config_mount_dir }}:/opt/uwsgi/conf


### PR DESCRIPTION
Hey @shrnkld, I just realized my most recent PR is not going to work for people wanting to deploy AVAX node and start it syncing. Since I just suggested in the announcement I made in #snode-general that people do exactly that, would you do me a favor and quickly merge this fix? I've tested it and it seems to work.

Note: This is really just a temp fix because desac is going to rework the autobuild stuff soon to support full XQuery deployment anyway.