### PR TITLE
add optional parameter 'chainstate_mount_dir'.

### DIFF
--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -18,7 +18,10 @@ services:
     volumes:
       - {{ daemon.config_mount_dir }}/{{ daemon.name }}/config:/opt/blockchain/config
       - {{ daemon.data_mount_dir }}/{{ daemon.name }}/data:/opt/blockchain/data
-      - type: bind
+    {% if daemon.chainstate_mount_dir is defined  %}
+  - {{ daemon.chainstate_mount_dir }}/{{ daemon.name }}/data/chainstate:/opt/blockchain/data/chainstate
+    {% endif %}
+  - type: bind
         source: ./scripts/entrypoints/start-{{ daemon.configName }}.sh
         target: /opt/blockchain/start-{{ daemon.configName }}.sh
     networks:

--- a/autobuild/utils/autoconfig.py
+++ b/autobuild/utils/autoconfig.py
@@ -26,6 +26,7 @@ def template_vars(template_path):
         contents = file.read()
         variables = jinja2schema.infer(contents)
         variables = jinja2schema.to_json_schema(variables)
+        variables['properties']['daemons']['items']['required'].remove('chainstate_mount_dir')
         #parse schema
         d = {}
         for req in variables['required']:


### PR DESCRIPTION
add optional parameter 'chainstate_mount_dir' to use in alldaemons.yaml during setup.
tested on my side, working as intended:
custom.yaml:
>    - name: BTC
>      image: blocknetdx/bitcoin:v0.20.0
>      config_mount_dir: /data/snode
>      data_mount_dir: /data/snode
>      chainstate_mount_dir: /snode

produce dockercompose.yml:

>    volumes:
>      - /data/snode/BTC/config:/opt/blockchain/config
>      - /data/snode/BTC/data:/opt/blockchain/data
>      - /snode/BTC/data/chainstate:/opt/blockchain/data/chainstate

if this variable is not set in custom.yaml, script ignore this mountpoint:
>    - name: SNODE # DO NOT DELETE
>      image: blocknetdx/servicenode:latest # DO NOT DELETE
>      config_mount_dir: /snode # DO NOT DELETE
>      data_mount_dir: /snode # DO NOT DELETE

produce:
>    volumes:
>      - /snode/snode/config:/opt/blockchain/config
>      - /snode/snode/data:/opt/blockchain/data