### PR TITLE
mandatory avalanchego bump from v1.7.1 to v1.7.2.

### DIFF
--- a/autobuild/examples/alldaemons.yaml
+++ b/autobuild/examples/alldaemons.yaml
@@ -19,7 +19,7 @@
       config_mount_dir: /snode # DO NOT DELETE
       data_mount_dir: /snode # DO NOT DELETE
     - name: AVAX # Requires 200 GB of disk, 16 GB RAM & 6 vCPUs (23 Nov, 2021)
-      image: avaplatform/avalanchego:v1.7.1
+      image: avaplatform/avalanchego:v1.7.2
       data_mount_dir: /snode
     - name: BTC # Requires 415.5 GB of disk (7 June, 2021)
       image: blocknetdx/bitcoin:v0.20.0


### PR DESCRIPTION
This is an important version bump. avalanchego  v1.7.1 can cause your db to get corrupted, which will require bootstrapping from scratch again, which can take a week or so, depending on HW. Please approve ASAP!