### PR TITLE
Fixed ETH entry in alldaemons.yaml after split of payment processor

### DIFF
--- a/autobuild/examples/alldaemons.yaml
+++ b/autobuild/examples/alldaemons.yaml
@@ -19,8 +19,7 @@
       postgresql_data_mount_dir: /snode/eth_pymt_db
       # DELETE THE FOLLOWING ETH ENTRY IF YOU DON'T WANT TO DEPLOY A 10+ TB GETH NODE
     - name: ETH # DELETE THIS ENTRY IF YOUR SERVER DOESN'T MEET HW REQUIREMENTS: 10+ TB NVMe SSD storage (21 Dec, 2021), 16 GB RAM when GETH deployed locally
-      image: blocknetdx/eth-payment-processor:0.5.2 # DELETE THIS ENTRY IF YOUR SERVER DOESN'T MEET HW REQUIREMENTS
-      postgresql_data_mount_dir: /snode/eth_pymt_db # DELETE THIS ENTRY IF YOUR SERVER DOESN'T MEET HW REQUIREMENTS
+      image: ethereum/client-go:latest # DELETE THIS ENTRY IF YOUR SERVER DOESN'T MEET HW REQUIREMENTS
       geth_data_mount_dir: /snode # DELETE THIS ENTRY IF YOUR SERVER DOESN'T MEET HW REQUIREMENTS
     # AVALANCHE INDEXER - DELETE IF YOU DON'T WANT TO SUPPORT XQUERY
     - name: AVAX # Requires 300 GB of SSD disk, 16 GB RAM & 6 vCPUs for XQUERY (21 December, 2021)


### PR DESCRIPTION
Now that ETH has been split into a different container from the payment processor, I think these few lines for the ETH entry in `alldaemons.yaml` should be adjusted.