### PR TITLE
added tier1,2 payment amounts to xquery-gethEXT-avaxEXT.yaml

### DIFF
--- a/autobuild/examples/xquery-gethEXT-avaxEXT.yaml
+++ b/autobuild/examples/xquery-gethEXT-avaxEXT.yaml
@@ -12,6 +12,8 @@
     - name: ETH # DO NOT DELETE
       host: 192.168.32.10 #examaple IP for external geth 
     - name: PAYMENT # DO NOT DELETE
+      payment_tier1: 35
+      payment_tier2: 200
       image: blocknetdx/eth-payment-processor:0.6.0 # DO NOT DELETE
       postgresql_data_mount_dir: /snode/eth_pymt_db # DO NOT DELETE
     # DO NOT DELETE SNODE ENTRY


### PR DESCRIPTION
@pom11 I only found tier1 & tier2 payment amounts missing in one `.yaml` file: `xquery-gethEXT-avaxEXT.yaml`, so I added them there. I hope that's what you wanted.