### PR TITLE
Feature/xq templates

### DIFF
--- a/autobuild/requirements.txt
+++ b/autobuild/requirements.txt
@@ -5,3 +5,4 @@ ipcalc
 six
 markupsafe
 icecream
+rich

--- a/autobuild/xq.py
+++ b/autobuild/xq.py
@@ -4,6 +4,8 @@ import argparse
 from string import Template
 from rich import print
 
+xrouter_emoticon = ":twisted_rightwards_arrows:"
+
 def default_query(schema):
     return Template("""
     query MyQuery {
@@ -105,37 +107,33 @@ def xtx_query(txs_hash, schema):
 
 
 def run_help(host, project_id):
-    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help')
+    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help',timeout=300)
     if request.status_code == 200:
         return request.text
     else:
-        raise Exception("XQuery help failed to run by returning code of {}".format(request.status_code))
+        print("XQuery help failed to run by returning code of {}".format(request.status_code))
 
 def run_query(host, query, project_id, api_key):
     headers = {'Api-Key':f'{api_key}'}
-    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/indexer/', headers=headers, json={'query': query})
-    # request = requests.post(f'http://{host}/indexer/', headers=headers, json={'query': query})
+    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/indexer/', headers=headers, json={'query': query},timeout=300)
     if request.status_code == 200:
         return request.json()
     else:
-        raise Exception("XQuery call failed to run by returning code of {}".format(request.status_code))
+        print("XQuery call failed to run by returning code of {}".format(request.status_code))
 
 def run_get_graph(host, project_id):
-    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help/graph')
+    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help/graph',timeout=300)
     if request.status_code == 200:
         return request.json()
     else:
-        print(request.text)
-        raise Exception("XQuery current graph failed to run by returning code of {}".format(request.status_code))
+        print("XQuery current graph failed to run by returning code of {}".format(request.status_code))
 
 def run_get_schema(host, project_id):
-    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help/schema')
-    # request = requests.get(f'http://{host}/help/schema')
+    request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help/schema',timeout=300)
     if request.status_code == 200:
         return request.text
     else:
-        print(request.text)
-        raise Exception("XQuery schema failed to run by returning code of {}".format(request.status_code))
+        print("XQuery schema failed to run by returning code of {}".format(request.status_code))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -180,12 +178,12 @@ if __name__ == '__main__':
                             p1 = pair.split("/")[1]
                             pairs.append([p0,p1])
                 query_pairs = xpair_query(pairs, schema, XQLIMIT)
-                print(":twisted_rightwards_arrows:",f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]pair[/bold yellow]' if len(XQPAIR)==1 else '[bold yellow]pairs[/bold yellow]'} {' '.join(XQPAIR)} ")
+                print(xrouter_emoticon,f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]pair[/bold yellow]' if len(XQPAIR)==1 else '[bold yellow]pairs[/bold yellow]'} {' '.join(XQPAIR)} ")
                 results = run_query(HOST, query_pairs, PROJECTID, APIKEY)
                 print(results)
             elif not XQPAIR and XQROUTER:
                 query_routers = xfilter_query(XQROUTER, schema, XQLIMIT)
-                print(":twisted_rightwards_arrows:",f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]router[/bold yellow]' if len(XQROUTER)==1 else '[bold yellow]routers[/bold yellow]'} {' '.join(XQROUTER)} ")
+                print(xrouter_emoticon,f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]router[/bold yellow]' if len(XQROUTER)==1 else '[bold yellow]routers[/bold yellow]'} {' '.join(XQROUTER)} ")
                 results = run_query(HOST, query_routers, PROJECTID, APIKEY)
                 print(results)
             elif XQPAIR and XQROUTER:
@@ -199,38 +197,38 @@ if __name__ == '__main__':
                             p1 = pair.split("/")[1]
                             pairs.append([p0,p1])
                 query_pair_router = xpair_filter_query(pairs, XQROUTER, schema, XQLIMIT)
-                print(":twisted_rightwards_arrows:",f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]router[/bold yellow]' if len(XQROUTER)==1 else '[bold yellow]routers[/bold yellow]'} {' '.join(XQROUTER)} and {'pair' if len(XQPAIR)==1 else 'pairs'} {' '.join(XQPAIR)}")
+                print(xrouter_emoticon,f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]router[/bold yellow]' if len(XQROUTER)==1 else '[bold yellow]routers[/bold yellow]'} {' '.join(XQROUTER)} and {'pair' if len(XQPAIR)==1 else 'pairs'} {' '.join(XQPAIR)}")
                 results = run_query(HOST, query_pair_router, PROJECTID, APIKEY)
                 print(results)
             elif XQADDRESS:
                 query_address = xaddress_query(XQADDRESS, schema, XQLIMIT)
-                print(":twisted_rightwards_arrows:",f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]address[/bold yellow]' if len(XQADDRESS)==1 else '[bold yellow]addresses[/bold yellow]'} {' '.join(XQADDRESS)}")
+                print(xrouter_emoticon,f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]address[/bold yellow]' if len(XQADDRESS)==1 else '[bold yellow]addresses[/bold yellow]'} {' '.join(XQADDRESS)}")
                 results = run_query(HOST, query_address, PROJECTID, APIKEY)
                 print(results)
             elif XQTX:
                 query_tx = xtx_query(XQTX, schema)
-                print(":twisted_rightwards_arrows:",f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]TX[/bold yellow]' if len(XQTX)==1 else '[bold yellow]TXs[/bold yellow]'} {' '.join(XQTX)}")
+                print(xrouter_emoticon,f"[bold magenta]XQuery[/bold magenta] for {'[bold yellow]TX[/bold yellow]' if len(XQTX)==1 else '[bold yellow]TXs[/bold yellow]'} {' '.join(XQTX)}")
                 results = run_query(HOST, query_tx, PROJECTID, APIKEY)
                 print(results)
             elif XQUERY:
-                print(":twisted_rightwards_arrows:","[bold magenta]XQuery[/bold magenta] for [bold yellow]custom query[/bold yellow]")
+                print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] for [bold yellow]custom query[/bold yellow]")
                 results = run_query(HOST, XQUERY, PROJECTID, APIKEY)
                 print(results)
             else:
                 default = default_query(schema)
-                print(":twisted_rightwards_arrows:","[bold magenta]XQuery[/bold magenta] for [bold yellow]last 20 entries[/bold yellow]")
+                print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] for [bold yellow]last 20 entries[/bold yellow]")
                 results = run_query(HOST, default, PROJECTID, APIKEY)
                 print(results)
         elif XQHELP and PROJECTID:
-            print(":twisted_rightwards_arrows:","[bold magenta]XQuery[/bold magenta] [bold yellow]help[/bold yellow]")
+            print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] [bold yellow]help[/bold yellow]")
             results = run_help(HOST, PROJECTID)
             print(results)
         elif XQGRAPH and PROJECTID:
-            print(":twisted_rightwards_arrows:","[bold magenta]XQuery[/bold magenta] [bold yellow]current graph[/bold yellow]")
+            print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] [bold yellow]current graph[/bold yellow]")
             results = run_get_graph(HOST, PROJECTID)
             print(results)
         elif XQSCHEMA and PROJECTID:
-            print(":twisted_rightwards_arrows:","[bold magenta]XQuery[/bold magenta] [bold yellow]schema[/bold yellow]")
+            print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] [bold yellow]schema[/bold yellow]")
             results = run_get_schema(HOST, PROJECTID)
             print(results)
         else:

--- a/autobuild/xq.py
+++ b/autobuild/xq.py
@@ -1,27 +1,163 @@
 import json
 import requests
 import argparse
+from string import Template
 
-query = """
+schema = """
+  id
+  xquery_chain_name
+  xquery_query_name
+  xquery_timestamp
+  xquery_tx_hash
+  xquery_token0_name
+  xquery_token0_symbol
+  xquery_token0_decimals
+  xquery_token1_name
+  xquery_token1_symbol
+  xquery_token1_decimals
+  xquery_side
+  xquery_address_filter
+  xquery_blocknumber
+  xquery_fn_name
+  xquery_from
+  xquery_to
+  xquery_value
+  xquery_src
+  xquery_wad
+  xquery_dst
+  xquery_owner
+  xquery_spender
+  xquery_sender
+  xquery_amount0
+  xquery_amount1
+  xquery_amount0in
+  xquery_amount1in
+  xquery_amount0out
+  xquery_amount1out
+  xquery_reserve0
+  xquery_reserve1
+  xquery_none
+  xquery_deadline
+  xquery_v
+  xquery_r
+  xquery_s
+  xquery_data
+  xquery_params
+  xquery_token
+  xquery_nonce
+  xquery_expiry
+  xquery_amountminimum
+  xquery_recipient
+  xquery_feebips
+  xquery_feerecipient
+  xquery_amount0delta
+  xquery_amount1delta
+  xquery_tokena
+  xquery_tokenb
+  xquery_amountadesired
+  xquery_amountbdesired
+  xquery_amountamin
+  xquery_amountbmin
+  xquery_amounttokendesired
+  xquery_amounttokenmin
+  xquery_amountavaxmin
+  xquery_amountout
+  xquery_reservein
+  xquery_reserveout
+  xquery_amountin
+  xquery_path
+  xquery_amounta
+  xquery_reservea
+  xquery_reserveb
+  xquery_liquidity
+  xquery_approvemax
+  xquery_amountoutmin
+  xquery_amountinmax
+"""
+
+query = Template("""
 query MyQuery {
-  xquery(where: {xquery_chain_name: {_eq: "AVAX"}, xquery_query_name: {_eq: "Swap"}}, limit: 10) {
-    xquery_sender
-    xquery_amount0in
-    xquery_amount1in
-    xquery_amount0out
-    xquery_amount1out
-    xquery_to
-    xquery_token1_symbol
-    xquery_token1_name
-    xquery_token1_decimals
-    xquery_token0_symbol
-    xquery_token0_name
-    xquery_token0_decimals
-    xquery_blocknumber
-    xquery_timestamp
-    xquery_tx_hash
+  xquery(where: {xquery_chain_name: {_eq: "AVAX"}, xquery_query_name: {_eq: "Swap"} }, limit: 20) {
+  $schema
   }
-}"""
+}""").substitute(schema=schema)
+
+def xpair_query(pairs, limit=20):
+    pair_filter = []
+    for pair in pairs:
+        pair_filter.append(Template("""{xquery_token0_symbol: {_regex: "$token0"}, xquery_token1_symbol: {_regex: "$token1"} }""").substitute(token0=pair[0],token1=pair[1]))
+        pair_filter.append(Template("""{xquery_token0_symbol: {_regex: "$token0"}, xquery_token1_symbol: {_regex: "$token1"} }""").substitute(token0=pair[1],token1=pair[0]))
+    template = Template("""
+    query XPair {
+      xquery(where: {
+    _or: [
+      $combo
+    ], 
+  }, limit: $limit) {
+    $schema
+    }
+}""").substitute(combo=','.join(pair_filter), schema=schema, limit=limit)
+    return template
+
+def xfilter_query(routers, limit=20):
+    router_names = []
+    for router in routers:
+        router_names.append(Template("""{xquery_address_filter: {_regex: "$router"} }""").substitute(router=router))
+    return Tempalte("""
+    query XAddressFilter {
+      xquery(where: {
+    _or: [
+      $combo
+    ], 
+  }, limit: $limit) {
+    $schema
+    }
+}""").substitute(combo=','.join(router_names), schema=schema, limit=limit)
+
+
+def xpair_filter_query(pairs, routers, limit=20):
+    combos = []
+    for router in routers:
+        c = []
+        c.append(Template("""xquery_address_filter: {_regex: "$router"}""").substitute(router=router))
+        for pair in pairs:
+            c.append(Template("""xquery_token0_symbol: {_regex: "$token0"}, xquery_token1_symbol: {_regex: "$token1"}""").substitute(token0=pair[0],token1=pair[1]))
+            c.append(Template("""xquery_token0_symbol: {_regex: "$token0"}, xquery_token1_symbol: {_regex: "$token1"}""").substitute(token0=pair[1],token1=pair[0]))
+        c = ','.join(c)
+        c = '{'+c+'}'
+        combos.append(c)
+    return Tempalte("""
+    query XPairXAddressFilter {
+      xquery(where: {
+    _or: [
+      $combo
+    ], 
+  }, limit: $limit) {
+    $schema
+    }
+}""").substitute(combo=','.join(combos), schema=schema, limit=limit)
+
+def xaddress(addresses, limit=20):
+    c = []
+    for address in addresses:
+        c.append(Template("""{xquery_to: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_sender: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_from: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_spender: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_recipient: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_path: {_regex: "$address"} }""").substitute(address=address))
+        c.append(Template("""{xquery_owner: {_regex: "$address"} }""").substitute(address=address))
+    return Template("""
+    query XAddress {
+      xquery(where: {
+    _or: [
+      $combo
+    ], 
+  }, limit: $limit) {
+    $schema
+    }
+}""").substitute(combo=','.join(c), schema=schema, limit=limit)
+
 
 def run_help(host, project_id):
     request = requests.post(f'http://{host}/xrs/xquery/{project_id}/help')
@@ -59,23 +195,25 @@ if __name__ == '__main__':
     parser.add_argument('--host', help='Host of EXR', default='127.0.0.1:80')
     parser.add_argument('--projectid', help='ID of EXR project', default=False)
     parser.add_argument('--apikey', help='API-KEY of EXR project', default=False)
-    parser.add_argument('--query', help='Query string', default=query)
+    parser.add_argument('--xquery', help='Query string', default=query)
     parser.add_argument('--xqhelp', help='Display XQuery help message', action='store_true')
     parser.add_argument('--xqgraph', help='Display XQuery current graph', action='store_true')
     parser.add_argument('--xqschema', help='Display XQuery schema', action='store_true')
+    parser.add_argument('--xqaddress', help='Address to query for', nargs='*')
+    parser.add_argument('--xqpair', help='Pairs to query for | USDC/USDT ETH/USDT', nargs='*')
+    parser.add_argument('--xqrouter', help='Routers names to query for | Uniswap Pangolin', nargs='*')
 
     args = parser.parse_args()
     HOST = args.host
     PROJECTID = args.projectid
     APIKEY = args.apikey
-    QUERY = args.query
+    XQUERY = args.xquery
     XQHELP = args.xqhelp
     XQGRAPH = args.xqgraph
     XQSCHEMA = args.xqschema
 
-    
     if PROJECTID and APIKEY:
-        results = run_query(HOST, QUERY, PROJECTID, APIKEY)
+        results = run_query(HOST, XQUERY, PROJECTID, APIKEY)
         print("#### XQuery query")
         print(results)
     elif XQHELP and PROJECTID:

--- a/autobuild/xq.py
+++ b/autobuild/xq.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':
             if XQPAIR and not XQROUTER:
                 pairs = []
                 for pair in XQPAIR:
-                    if "/" not in pair and pair.count("/")!=1:
+                    if "/" not in pair or pair.count("/")!=1:
                         print(":x:",f"ignoring unknown format {pair}...")
                     else:
                         if XQPAIR.count(pair)==1:
@@ -189,7 +189,7 @@ if __name__ == '__main__':
             elif XQPAIR and XQROUTER:
                 pairs = []
                 for pair in XQPAIR:
-                    if "/" not in pair and pair.count("/")!=1:
+                    if "/" not in pair or pair.count("/")!=1:
                         print(":x:",f"ignoring unknown format {pair}...")
                     else:
                         if XQPAIR.count(pair)==1:

--- a/autobuild/xq.py
+++ b/autobuild/xq.py
@@ -79,7 +79,7 @@ schema = """
 
 query = Template("""
 query MyQuery {
-  xquery(where: {xquery_chain_name: {_eq: "AVAX"}, xquery_query_name: {_eq: "Swap"} }, limit: 20) {
+  xquery(order_by: {xquery_blocknumber: desc}, where: {xquery_chain_name: {_eq: "AVAX"}, xquery_query_name: {_eq: "Swap"} }, limit: 20) {
   $schema
   }
 }""").substitute(schema=schema)
@@ -91,7 +91,7 @@ def xpair_query(pairs, limit=20):
         pair_filter.append(Template("""{xquery_token0_symbol: {_regex: "$token0"}, xquery_token1_symbol: {_regex: "$token1"} }""").substitute(token0=pair[1],token1=pair[0]))
     template = Template("""
     query XPair {
-      xquery(where: {
+      xquery(order_by: {xquery_blocknumber: desc}, where: {
     _or: [
       $combo
     ], 
@@ -105,9 +105,9 @@ def xfilter_query(routers, limit=20):
     router_names = []
     for router in routers:
         router_names.append(Template("""{xquery_address_filter: {_regex: "$router"} }""").substitute(router=router))
-    return Tempalte("""
+    return Template("""
     query XAddressFilter {
-      xquery(where: {
+      xquery(order_by: {xquery_blocknumber: desc}, where: {
     _or: [
       $combo
     ], 
@@ -128,9 +128,9 @@ def xpair_filter_query(pairs, routers, limit=20):
         c = ','.join(c)
         c = '{'+c+'}'
         combos.append(c)
-    return Tempalte("""
+    return Template("""
     query XPairXAddressFilter {
-      xquery(where: {
+      xquery(order_by: {xquery_blocknumber: desc}, where: {
     _or: [
       $combo
     ], 
@@ -151,7 +151,7 @@ def xaddress_query(addresses, limit=20):
         c.append(Template("""{xquery_owner: {_regex: "$address"} }""").substitute(address=address))
     return Template("""
     query XAddress {
-      xquery(where: {
+      xquery(order_by: {xquery_blocknumber: desc}, where: {
     _or: [
       $combo
     ], 
@@ -257,7 +257,7 @@ if __name__ == '__main__':
         elif XQADDRESS:
             query_address = xaddress_query(XQADDRESS, XQLIMIT)
             results = run_query(HOST, query_address, PROJECTID, APIKEY)
-            print(f"#### XQuery for {'address' if len(XQADDRESS)==1 else 'addresses'} {XQADDRESS}")
+            print(f"#### XQuery for {'address' if len(XQADDRESS)==1 else 'addresses'} {' '.join(XQADDRESS)}")
             print(results)
         else:
             results = run_query(HOST, XQUERY, PROJECTID, APIKEY)

--- a/autobuild/xq.py
+++ b/autobuild/xq.py
@@ -212,7 +212,7 @@ if __name__ == '__main__':
                 print(results)
             elif XQUERY:
                 print(xrouter_emoticon,"[bold magenta]XQuery[/bold magenta] for [bold yellow]custom query[/bold yellow]")
-                results = run_query(HOST, XQUERY, PROJECTID, APIKEY)
+                results = run_query(HOST, json.loads(XQUERY), PROJECTID, APIKEY)
                 print(results)
             else:
                 default = default_query(schema)


### PR DESCRIPTION
Closes #110;

added the possibility to query for:
- pair/pairs via `--xqpair token1/token2` or `--xqpair token1/token2 token11/token22`
- router_name/s via `--xqrouter Pangolin` or `--xqrouter Pangolin Uniswap`
- address/es via `--xqaddress MY_ADDRESS` or `--xqaddress MY_ADDRESS1 MY_ADDRESS2`
- tx/txs via `--xqtx TX` or `--xqtx TX1 TX2`
- limit results number via `--xqlimit N` - fetch last N results for the above arguments

QA:
*make sure `rich` is installed. `pip3 install rich`*

Check
- [ ]  --xqpair
- [ ]  --xqrouter
- [ ]  --xqpair --xqrouter (these 2 work also combined)
- [ ]  --xqaddress
- [ ]  --xqtx
- [ ]  --xqlimit