### PR TITLE
Bumped  MUE entry in sources.yaml to v2.3.0

### DIFF
--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -102,7 +102,7 @@
 
 - name: MUE 
   type: chain
-  image: blocknetdx/monetaryunit:v2.2.0
+  image: blocknetdx/monetaryunit:v2.3.0
   volume: /snode
   disk: 6
   ram: 5


### PR DESCRIPTION
After recent updates to `blockchain-configuration-files` repo, current MUE entry in `autobuild/sources.yaml` breaks trying to reference v2.2.0. This fixes that breakage.