### PR TITLE
Feature sys

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ optional arguments:
   --yaml YAML           Custom input yaml
   --interval INTERVAL   Docker stopping interval till sends SIGKILL signal; default 30s
   --branchpath BRANCHPATH
+  --xquerytag TAG 
   --prunecache          Reinit .known_hosts, .known_volumes, .env and .cache
                         files
   --subnet SUBNET       Subnet to configure docker-compose network 

--- a/auto_test/exr_methods.py
+++ b/auto_test/exr_methods.py
@@ -88,9 +88,11 @@ if __name__ == '__main__':
     if args.command == 'project':
         API_Key = args.api_key
         project_id = args.project_id
-        chains = ['AVAX','ETH']
+        chains = ['AVAX','ETH', 'SYS']
         for chain in chains:
             if chain =='ETH':
+                url = http_socket + '/xrs/evm_passthrough'+f'/{chain}'+f'/{project_id}'
+            elif chain =='SYS':
                 url = http_socket + '/xrs/evm_passthrough'+f'/{chain}'+f'/{project_id}'
             elif chain =='AVAX':
                 url = http_socket + '/xrs/evm_passthrough'+f'/{chain}'+f'/{project_id}'+'/ext/bc/C/rpc'

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -22,6 +22,7 @@
   payment_tier2: 200
   discount_ablock: 20
   discount_aablock: 0      
+  discount_sysblock: 10      
   image: blocknetdx/eth-payment-processor:latest
   volume: /snode
   disk: 1
@@ -44,14 +45,6 @@
   ram: 16
   cpu: 6
 
-#- name: SYS
-#  type: evm_chain 
-#  image: blocknetdx/syscoin4:v4.3.0
-#  volume: /snode
-#  disk: 7
-#  ram: 5
-#  cpu: 4
-#
 - name: BTC 
   type: chain
   image: blocknetdx/bitcoin:v0.20.0
@@ -157,12 +150,21 @@
   cpu: 4
 
 - name: SYS 
-  type: chain
+  type: hybrid
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
   disk: 7
   ram: 5
   cpu: 4
+
+- name: NEVM
+  type: evm_chain
+  image: blocknetdx/syscoin4:v4.3.0
+  volume: /snode
+  disk: 7
+  ram: 5
+  cpu: 4
+
 
 - name: UNO 
   type: chain
@@ -181,7 +183,7 @@
   chains:
     - name: AVAX
     - name: ETH
-#    - name: SYS
+    - name: NEVM
       
 #- name: XQUERY
 #  type: app

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -185,95 +185,95 @@
     - name: ETH
     - name: NEVM
       
-#- name: XQUERY
-#  type: app
-#  volume: /snode
-#  disk: 5
-#  ram: 16
-#  cpu: 32
-#  graph: AVAX_ETH_SYS
-#  endpoint: /indexer
-#  chains:
-#    - name: AVAX_PANGOLIN
-#      abi: pangolinRouter.json
-#      query:
-#        - name: Withdrawal
-#        - name: Deposit
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#      address:
-#      - name: Pangolin_Router
-#        address: '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106'
-#      historical:
-#      - fromBlock: "57347"
-#    - name: ETH_UNISWAP_v2
-#      abi: uniswapRouter_v2.json
-#      query:
-#        - name: Withdrawal
-#        - name: Deposit
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#      address:
-#      - name: Uniswap_Router_v2
-#        address: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
-#      historical:
-#      - fromBlock: "10207858"
-#    - name: ETH_UNISWAP_v3
-#      abi: uniswapRouter_v3.json
-#      query:
-#        - name: Withdrawal
-#        - name: Deposit
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#      address:
-#      - name: Uniswap_Router_v3
-#        address: '0xe592427a0aece92de3edee1f18e0157c05861564'
-#      historical:
-#      - fromBlock: "12369634"
-#    - name: SYS_PEGASYS
-#      #rpc_host: https://rpc.syscoin.org/
-#      abi: abi/pegasysRouter.json
-#      query:
-#        - name: Withdrawal
-#        - name: Deposit
-#        - name: Approval
-#        - name: Burn
-#        - name: Mint
-#        - name: Swap
-#        - name: Sync
-#        - name: Transfer
-#      address:
-#      - name: Pegasys_Router
-#        address: '0x017dAd2578372CAEE5c6CddfE35eEDB3728544C4'
-#      historical:
-#      - fromBlock: "1"
+- name: XQUERY
+  type: app
+  volume: /snode
+  disk: 5
+  ram: 16
+  cpu: 32
+  graph: AVAX_ETH_SYS
+  endpoint: /indexer
+  chains:
+    - name: AVAX_PANGOLIN
+      abi: pangolinRouter.json
+      query:
+        - name: Withdrawal
+        - name: Deposit
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+      address:
+      - name: Pangolin_Router
+        address: '0xE54Ca86531e17Ef3616d22Ca28b0D458b6C89106'
+      historical:
+      - fromBlock: "57347"
+    - name: ETH_UNISWAP_v2
+      abi: uniswapRouter_v2.json
+      query:
+        - name: Withdrawal
+        - name: Deposit
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+      address:
+      - name: Uniswap_Router_v2
+        address: '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
+      historical:
+      - fromBlock: "10207858"
+    - name: ETH_UNISWAP_v3
+      abi: uniswapRouter_v3.json
+      query:
+        - name: Withdrawal
+        - name: Deposit
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+      address:
+      - name: Uniswap_Router_v3
+        address: '0xe592427a0aece92de3edee1f18e0157c05861564'
+      historical:
+      - fromBlock: "12369634"
+    - name: NEVM_PEGASYS
+      #rpc_host: https://rpc.syscoin.org/
+      abi: abi/pegasysRouter.json
+      query:
+        - name: Withdrawal
+        - name: Deposit
+        - name: Approval
+        - name: Burn
+        - name: Mint
+        - name: Swap
+        - name: Sync
+        - name: Transfer
+      address:
+      - name: Pegasys_Router
+        address: '0x017dAd2578372CAEE5c6CddfE35eEDB3728544C4'
+      historical:
+      - fromBlock: "1"

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -276,4 +276,4 @@
       - name: Pegasys_Router
         address: '0x017dAd2578372CAEE5c6CddfE35eEDB3728544C4'
       historical:
-      - fromBlock: "1"
+      - fromBlock: "38202"

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -191,7 +191,7 @@
   disk: 5
   ram: 16
   cpu: 32
-  graph: AVAX_ETH_SYS
+  graph: AVAX_ETH_NEVM
   endpoint: /indexer
   chains:
     - name: AVAX_PANGOLIN
@@ -262,7 +262,7 @@
       - fromBlock: "12369634"
     - name: NEVM_PEGASYS
       #rpc_host: https://rpc.syscoin.org/
-      abi: abi/pegasysRouter.json
+      abi: pegasysRouter.json
       query:
         - name: Withdrawal
         - name: Deposit

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -8,6 +8,14 @@ services:
     expose:
       - {{ daemon.rpcPort }}
       - {{ daemon.p2pPort }}
+{% if deploy_nevm and daemon.name == 'SYS' %}
+      - 8545
+      - 30303
+    ports:
+      - "8369:8369"
+      - "8545:8545"
+      - "30303:30303"
+{% endif %}
     entrypoint: /opt/blockchain/start-{{ daemon.configName }}.sh
     command:
       - {{ daemon.binFile }}
@@ -15,11 +23,15 @@ services:
       RPC_USER: "${RPC_USER}"
       RPC_PASSWORD: "${RPC_PASSWORD}"
       RPC_ALLOWIP: 172.31.0.0/20
+{% if deploy_nevm and daemon.name == 'SYS' %}
+    stop_signal: SIGINT
+    stop_grace_period: 4m
+{% endif %}
     volumes:
       - {{ daemon.volume }}/{{ daemon.name }}/config:/opt/blockchain/config
       - {{ daemon.volume }}/{{ daemon.name }}/data:/opt/blockchain/data
     {% if daemon.chainstate is defined  %}
-  - {{ daemon.chainstate }}/{{ daemon.name }}/data/chainstate:/opt/blockchain/data/chainstate
+      - {{ daemon.chainstate }}/{{ daemon.name }}/data/chainstate:/opt/blockchain/data/chainstate
     {% endif %}
   - type: bind
         source: ./scripts/entrypoints/start-{{ daemon.configName }}.sh
@@ -166,7 +178,7 @@ services:
 {% endif %}
 {% endif %}
 
-{% if deploy_eth or deploy_avax %}
+{% if deploy_eth or deploy_avax or deploy_nevm %}
 {% if deploy_payment %}
   payment:
     image: {{ payment_image }}
@@ -182,6 +194,11 @@ services:
       AVAX_PORT: 9650
       AVAX_HOST_TYPE: http
 {% endif %}
+{% if deploy_nevm %}
+      NEVM_HOST: {{ nevm_ip }}
+      NEVM_PORT: 8545
+      NEVM_HOST_TYPE: http
+{% endif %}
 {% if avaxexternal %}
       AVAX_HOST: {{ avax_ip }}
       AVAX_PORT: 9650
@@ -191,6 +208,7 @@ services:
       PAYMENT_AMOUNT_TIER2: {{ payment_tier2 }}
       DISCOUNT_ABLOCK: {{ payment_discount_ablock }}
       DISCOUNT_AABLOCK: {{ payment_discount_aablock }}
+      DISCOUNT_SYSBLOCK: {{ payment_discount_sysblock }}
       DB_HOST: {{ pg_ip }}
       DB_USERNAME: ethproxy
       DB_PASSWORD: password
@@ -205,6 +223,9 @@ services:
 {% endif %}
 {% if deploy_avax %}
       - avax
+{% endif %}
+{% if deploy_nevm %}
+      - sys
 {% endif %}
       - payment_db
     logging:
@@ -259,7 +280,11 @@ services:
       AVAX_HOST: {{ avax_ip }}
       AVAX_IP: 9650
 {% endif %}
-{% if deploy_eth or deploy_avax %}
+{% if deploy_nevm %}
+      NEVM_HOST: {{ nevm_ip }}
+      NEVM_IP: 8545
+{% endif %}
+{% if deploy_eth or deploy_avax or deploy_nevm %}
 {% if deploy_payment %}
       PAYMENT_PROCESSOR_HOST: {{ payment_ip }}:8080
       DB_HOST: {{ pg_ip }}

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -23,9 +23,11 @@ services:
       RPC_USER: "${RPC_USER}"
       RPC_PASSWORD: "${RPC_PASSWORD}"
       RPC_ALLOWIP: 172.31.0.0/20
-{% if deploy_nevm and daemon.name == 'SYS' %}
     stop_signal: SIGINT
-    stop_grace_period: 4m
+{% if daemon.name == 'SYS' %}
+    stop_grace_period: 20m
+{% else %}
+    stop_grace_period: 10m
 {% endif %}
     volumes:
       - {{ daemon.volume }}/{{ daemon.name }}/config:/opt/blockchain/config
@@ -59,6 +61,8 @@ services:
       SN_ADDRESS: "${SN_ADDRESS}"
       SN_KEY: "${SN_KEY}"
 {% endif %}
+    stop_signal: SIGINT
+    stop_grace_period: 10m
     volumes:
 {% if blocknet_node == 'snode' %}
       - {{ snode_volume }}/snode/config:/opt/blockchain/config
@@ -82,10 +86,17 @@ services:
       - type: bind
         source: ./scripts/config/xbridge.conf
         target: /opt/blockchain/data/xbridge.conf
+{% if blocknet_node == 'snode' or blocknet_node == 'tnode' %}
     ports:
       - "41412:41412"
     expose:
       - 41412
+{% elif blocknet_node == 'testsnode' or blocknet_node == 'testtnode' %}
+    ports:
+      - "41474:41474"
+    expose:
+      - 41474
+{% endif %}
     logging:
       driver: "json-file"
       options:
@@ -118,6 +129,8 @@ services:
       - --public-ip={{ avax_public_ip }}
     volumes:
       - {{ avax_volume }}/AVAX:/data
+    stop_signal: SIGINT
+    stop_grace_period: 5m
     logging:
       driver: "json-file"
       options:
@@ -141,7 +154,7 @@ services:
     volumes:
       - {{ eth_volume }}/ETH:/chaindata
     stop_signal: SIGINT
-    stop_grace_period: 2m
+    stop_grace_period: 5m
     command:
 {% if eth_testnet %}
       - --{{ eth_testnet }}

--- a/autobuild/templates/entrypoint_config.j2
+++ b/autobuild/templates/entrypoint_config.j2
@@ -9,6 +9,27 @@ rpcallowip=172.31.0.0/20
 
 {{ walletConfig }}
 
+{% if writeNEVM %}
+# NEVM startup options
+gethcommandline=--syncmode=full
+gethcommandline=--gcmode=archive
+gethcommandline=--http
+gethcommandline=--http.addr={{ nevmIP }}
+gethcommandline=--http.api=admin,debug,eth,miner,net,personal,txpool,web3
+gethcommandline=--http.rpcprefix=/
+gethcommandline=--http.vhosts=*
+gethcommandline=--ws
+gethcommandline=--ws.addr={{ nevmIP }}
+gethcommandline=--ws.api=personal,eth,net,web3
+gethcommandline=--ws.rpcprefix=/
+gethcommandline=--ws.origins=*
+gethcommandline=--graphql
+gethcommandline=--graphql.vhosts=*
+#gethcommandline=--pprof
+#gethcommandline=--pprof.addr={{ nevmIP }}
+#gethcommandline=--metrics
+#gethcommandline=--metrics.addr={{ nevmIP }}
+{% endif %}
 
 EOL
 

--- a/autobuild/templates/xquery.j2
+++ b/autobuild/templates/xquery.j2
@@ -2,7 +2,7 @@
 {% for event_type in chain.query %}
 ####{{ chain.name.lower()+'_'+event_type.name.lower() }} STACK START
   xquery-event-processor-{{ chain.name.lower() | replace('_','-') }}-{{ event_type.name.lower() }}:
-    image: blocknetdx/xquery-event-processor:latest
+    image: blocknetdx/xquery-event-processor:{{ xquery_tag }}
     depends_on:
       - "xquery-graphql-engine"
       - "xquery-gateway-processor"
@@ -38,7 +38,7 @@
 {% endfor %}
 
   xquery-gateway-processor:
-    image: blocknetdx/xquery-gateway-processor:latest
+    image: blocknetdx/xquery-gateway-processor:{{ xquery_tag }}
     depends_on:
       - "xquery-postgres"
     restart: always
@@ -61,7 +61,7 @@
       backend:
         ipv4_address: {{ gateway_processor_ip }}
   xquery-db-processor:
-    image: blocknetdx/xquery-db-processor:latest
+    image: blocknetdx/xquery-db-processor:{{ xquery_tag }}
     depends_on:
       - "xquery-postgres"
     restart: always
@@ -132,7 +132,7 @@
       backend:
         ipv4_address: {{ graphql_engine_ip }}
   xquery-reverse-proxy:
-    image: blocknetdx/xquery-reverse-proxy:latest
+    image: blocknetdx/xquery-reverse-proxy:{{ xquery_tag }}
     restart: always
     environment:
       PORT: {{ reverse_proxy_port }}

--- a/autobuild/templates/xrproxy.j2
+++ b/autobuild/templates/xrproxy.j2
@@ -56,6 +56,11 @@ set-ph = AVAX_HOST_IP={{ avax_ip }}
 set-ph = AVAX_HOST_PORT=9650
 {% endif %}
 
+{% if deploy_nevm %}
+set-ph = NEVM_HOST_IP={{ nevm_ip }}
+set-ph = NEVM_HOST_PORT=8545
+{% endif %}
+
 
 {% if deploy_xquery %}
 set-ph = XQUERY_IP={{ reverse_proxy_ip }}

--- a/autobuild/utils/xquery.py
+++ b/autobuild/utils/xquery.py
@@ -22,6 +22,8 @@ def xq_template(used_ip, subnet, query, data):
 					item['rpc_host'] = f"http://{data['avax_ip']}:9650/ext/bc/C/rpc"
 				if 'ETH' in name:
 					item['rpc_host'] = f"http://{data['geth_ip']}:8545"
+				if 'SYS' in name:
+					item['rpc_host'] = f"http://{data['nevm_ip']}:8545"
 				item['query'] = [dict(t) for t in {tuple(d.items()) for d in item['query']}]
 				for event in item['query']:
 					if f'{name}_{event["name"]}' in used_ip['ip'].keys():

--- a/builder.py
+++ b/builder.py
@@ -13,7 +13,6 @@ from icecream import ic
 import subprocess
 
 # Global vars
-branchpath = re.sub(r'(^(?!.*/$).*)',r'\1/','https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master')
 KNOWN_HOSTS_FILE = '.known_hosts'
 KNOWN_VOLUMES = '.known_volumes'
 ENV_FILE = '.env'
@@ -50,7 +49,7 @@ parser.add_argument('--prune', help='Prune docker', default=False, action='store
 parser.add_argument('--source', help='Source file', default='autobuild/sources.yaml')
 parser.add_argument('--yaml', help='Custom input yaml', default=False)
 parser.add_argument('--interval', help='Docker stopping interval till sends SIGKILL signal; default 30s', default=30)
-parser.add_argument('--branchpath', default=branchpath)
+parser.add_argument('--branchpath', default='https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master')
 parser.add_argument('--xquerytag', help="Override XQuery images tag", default='latest')
 parser.add_argument('--prunecache', help='Reinit .known_hosts, .known_volumes, .env and .cache files', action='store_true')
 parser.add_argument('--subnet', help='Subnet to configure docker-compose network', default="172.31.0.0/20")
@@ -62,7 +61,8 @@ CHECKS = args.nochecks
 ENV = args.noenv
 DEPLOY = args.deploy
 PRUNE = args.prune
-BRANCHPATH = args.branchpath
+BRANCHPATH = re.sub(r'(^(?!.*/$).*)',r'\1/',args.branchpath)
+
 XQUERYTAG = args.xquerytag
 STOP_INTERVAL = int(args.interval)
 PRUNE_CACHE = args.prunecache
@@ -329,6 +329,7 @@ if __name__ == '__main__':
 
 		input_template_args[0]['daemons'] = input_template[0]['daemons']
 		input_template_args[0]['xquery_tag'] = XQUERYTAG
+        ic(BRANCHPATH)
 		data_with_ips = processcustom(input_template_args, SUBNET, BRANCHPATH)
 		processconfigs(data_with_ips, BRANCHPATH)
 		

--- a/builder.py
+++ b/builder.py
@@ -51,6 +51,7 @@ parser.add_argument('--source', help='Source file', default='autobuild/sources.y
 parser.add_argument('--yaml', help='Custom input yaml', default=False)
 parser.add_argument('--interval', help='Docker stopping interval till sends SIGKILL signal; default 30s', default=30)
 parser.add_argument('--branchpath', default=branchpath)
+parser.add_argument('--xquerytag', help="Override XQuery images tag", default='latest')
 parser.add_argument('--prunecache', help='Reinit .known_hosts, .known_volumes, .env and .cache files', action='store_true')
 parser.add_argument('--subnet', help='Subnet to configure docker-compose network', default="172.31.0.0/20")
 
@@ -62,6 +63,7 @@ ENV = args.noenv
 DEPLOY = args.deploy
 PRUNE = args.prune
 BRANCHPATH = args.branchpath
+XQUERYTAG = args.xquerytag
 STOP_INTERVAL = int(args.interval)
 PRUNE_CACHE = args.prunecache
 SUBNET = args.subnet
@@ -329,6 +331,7 @@ if __name__ == '__main__':
 				sys.exit(0)
 
 		input_template_args[0]['daemons'] = input_template[0]['daemons']
+		input_template_args[0]['xquery_tag'] = XQUERYTAG
 		data_with_ips = processcustom(input_template_args, SUBNET, BRANCHPATH)
 		processconfigs(data_with_ips, BRANCHPATH)
 		

--- a/builder.py
+++ b/builder.py
@@ -113,7 +113,7 @@ cache = json.loads(load_text_file(CACHE))
 # Upgrade cache if necessary
 if 'version' not in cache:
 	cache['version'] = 1
-	cache['discount_sysblock'] = 10
+	cache['discount_sysblock'] = None
 
 if __name__ == '__main__':
 	print(hw_table)
@@ -234,11 +234,11 @@ if __name__ == '__main__':
 			for b in base:				
 				if b['name'] == 'PAYMENT' and any([[True for x in [deploy['name'] for deploy in input_template[0]['daemons']] if x==xx] for xx in [echain['name'] for echain in evm_chains]]):
 					print(f"[bold magenta]{'-'*50}[/bold magenta]")
-					b['payment_tier1'] = cache["payment_tier1"] if cache["payment_tier1"] != None else 35
-					b['payment_tier2'] = cache["payment_tier2"] if cache["payment_tier2"] != None else 200
-					b['discount_ablock'] = cache["discount_ablock"] if cache["discount_ablock"] != None else 20
-					b['discount_aablock'] = cache["discount_aablock"] if cache["discount_aablock"] != None else 0
-					b['discount_sysblock'] = cache["discount_sysblock"] if cache["discount_sysblock"] != None else 10
+					if cache["payment_tier1"] != None: b['payment_tier1'] = cache["payment_tier1"] 
+					if cache["payment_tier2"] != None: b['payment_tier2'] = cache["payment_tier2"] 
+					if cache["discount_ablock"] != None: b['discount_ablock'] = cache["discount_ablock"] 
+					if cache["discount_aablock"] != None: b['discount_aablock'] = cache["discount_aablock"] 
+					if cache["discount_sysblock"] != None: b['discount_sysblock'] = cache["discount_sysblock"] 
 					tier1 = snode.inquirer.get_input(f'Press enter for {b["payment_tier1"]}USD tier1 amount or type a new USD price:')
 					b['payment_tier1'] = int(tier1) if tier1 !='' else b["payment_tier1"]
 					tier2 = snode.inquirer.get_input(f'Press enter for {b["payment_tier2"]}USD tier2 amount or type a new USD price:')

--- a/builder.py
+++ b/builder.py
@@ -99,7 +99,7 @@ if KNOWN_VOLUMES not in os.listdir(os.getcwd()):
 
 # Create .cache
 if CACHE not in os.listdir(os.getcwd()):
-	data = {'ticks':[],'payment_tier1':None,'payment_tier2':None,'discount_ablock':None,'discount_aablock':None,'discount_sysblock':None}
+	data = {'version':'1','ticks':[],'payment_tier1':None,'payment_tier2':None,'discount_ablock':None,'discount_aablock':None,'discount_sysblock':None}
 	write_text_file(CACHE,json.dumps(data, indent=4, sort_keys=False))
 
 # Load config files
@@ -109,6 +109,11 @@ source = load_yaml_file(SOURCE)
 known_hosts = json.loads(load_text_file(KNOWN_HOSTS_FILE))
 known_volumes = json.loads(load_text_file(KNOWN_VOLUMES))
 cache = json.loads(load_text_file(CACHE))
+
+# Upgrade cache if necessary
+if 'version' not in cache:
+	cache['version'] = 1
+	cache['discount_sysblock'] = 10
 
 if __name__ == '__main__':
 	print(hw_table)
@@ -180,9 +185,6 @@ if __name__ == '__main__':
 							if evcd in known_volumes['volumes'].keys():
 								evc['volume'] = known_volumes['volumes'][evcd]
 							input_template[0]['daemons'].append(evc)
-#							if evcd == 'NEVM':
-#								if syschain[0] not in input_template[0]['daemons']:
-#									input_template[0]['daemons'].append(syschain[0])
 			write_text_file(KNOWN_HOSTS_FILE,json.dumps(known_hosts, indent=4, sort_keys=False))
 			print(f"[bold magenta]{'-'*50}[/bold magenta]")
 			if len(evm_chains_todeploy)>0:
@@ -310,7 +312,7 @@ if __name__ == '__main__':
 				write_yaml_file(f'inputs_yaml/{now}.yaml',input_template)
 			else:
 				write_yaml_file(f'inputs_yaml/{config_name}.yaml',input_template)
-			cache = {'ticks':[],'payment_tier1':None,'payment_tier2':None,'discount_ablock':None,'discount_aablock':None}
+			cache = {'ticks':[],'payment_tier1':None,'payment_tier2':None,'discount_ablock':None,'discount_aablock':None,'discount_sysblock':None,'version':'1'}
 			for daemon in input_template[0]['daemons']:
 				cache['ticks'].append(daemon['name'])
 				if daemon['name'] == 'PAYMENT':

--- a/builder.py
+++ b/builder.py
@@ -234,16 +234,11 @@ if __name__ == '__main__':
 			for b in base:				
 				if b['name'] == 'PAYMENT' and any([[True for x in [deploy['name'] for deploy in input_template[0]['daemons']] if x==xx] for xx in [echain['name'] for echain in evm_chains]]):
 					print(f"[bold magenta]{'-'*50}[/bold magenta]")
-					if cache["payment_tier1"]:
-						b['payment_tier1'] = cache["payment_tier1"]
-					if cache["payment_tier2"]:
-						b['payment_tier2'] = cache["payment_tier2"]
-					if cache["discount_ablock"]:
-						b['discount_ablock'] = cache["discount_ablock"]
-					if cache["discount_aablock"]:
-						b['discount_aablock'] = cache["discount_aablock"]
-					if cache["discount_sysblock"]:
-						b['discount_sysblock'] = cache["discount_sysblock"]
+					b['payment_tier1'] = cache["payment_tier1"] if cache["payment_tier1"] != None else 35
+					b['payment_tier2'] = cache["payment_tier2"] if cache["payment_tier2"] != None else 200
+					b['discount_ablock'] = cache["discount_ablock"] if cache["discount_ablock"] != None else 20
+					b['discount_aablock'] = cache["discount_aablock"] if cache["discount_aablock"] != None else 0
+					b['discount_sysblock'] = cache["discount_sysblock"] if cache["discount_sysblock"] != None else 10
 					tier1 = snode.inquirer.get_input(f'Press enter for {b["payment_tier1"]}USD tier1 amount or type a new USD price:')
 					b['payment_tier1'] = int(tier1) if tier1 !='' else b["payment_tier1"]
 					tier2 = snode.inquirer.get_input(f'Press enter for {b["payment_tier2"]}USD tier2 amount or type a new USD price:')

--- a/cli/projects.py
+++ b/cli/projects.py
@@ -40,7 +40,11 @@ def exec_psql(cmd, host, database, user, password):
 		conn.autocommit = True
 		cursor = conn.cursor()
 		cursor.execute(cmd)
-		results = cursor.fetchall()
+		op,_=cmd.lower().split(maxsplit=1)
+		if op == 'select':
+			results = cursor.fetchall()
+		else:
+			results = f'{cursor.rowcount} row(s) affected'
 		conn.close()
 		return results
 	except Exception as e:
@@ -131,7 +135,7 @@ def help():
 		['--apicount', 'Change apicount number of a project in the [bold yellow]Project[/bold yellow] table'],
 		['--archive', 'Toggle the archive boolean of a project in [bold yellow]Project[/bold yellow] table'],
 		['--active', 'Toggle the active boolean of a project in [bold yellow]Project[/bold yellow] table '],
-		['--cmd', 'Send command to [bold cyan]payment_db[/bold cyan]'],
+		['--cmd', 'Send SQL to [bold cyan]payment_db[/bold cyan]'],
 		['--new', 'Request new Project ID and Api-Key']
 	]
 	for d in data:

--- a/cli/xq.py
+++ b/cli/xq.py
@@ -211,7 +211,7 @@ def help():
         ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqpair [bold yellow]PAIRS[/bold yellow]','Query for custom pairs'],
         ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqpair [bold yellow]PAIRS[/bold yellow] --xqrouter [bold yellow]ROUTERS[/bold yellow]','Query for custom pairs and routers'],
         ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqaddress [bold yellow]ADDRESSES[/bold yellow]','Query for custom addresses'],
-        ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqtx [bold yellow]TXS[/bold yellow]','Query for cutom txs'],
+        ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqtx [bold yellow]TXS[/bold yellow]','Query for custom txs'],
         ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqbmin [bold yellow]CHAIN[/bold yellow]','Query for minimum indexed blocknumber for a chain'],
         ['--projectid [bold yellow]PROJECTID[/bold yellow] --apikey [bold yellow]APIKEY[/bold yellow] --xqbmax [bold yellow]CHAIN[/bold yellow]','Query for maximum indexed blocknumber for a chain'],
     ]


### PR DESCRIPTION
Adds support for SYS NEVM to (awesome-)builder.py (& its minions).

I wanted to make it autoselect SYS for XBridge if user requests NEVM for Hydra/XQuery but it got a bit messy shoehorning that into the existing workflow (mainly due to chicken and egg scenarios with "what if they want external NEVM (with or without a purely XBridge SYS) so if users want local SYS NEVM they must select SYS for XBridge and then select NEVM for Hydra/XQuery.

Changes add the possibility of running archival NEVM (via config options in start-syscoin.sh) to an XBridge SYS container. Doesn't seem to break anything else I tested. 

@ConanMishler @shrnkld please test it if you have time rather than just visually review it. Depending on which set of XQuery containers you're using you may or may not be able to actually use XQuery....

The cosmetic width change at line 145 in builder.py is to accommodate DOGEC (and later, others). The sysblock discount is in anticipation of wrapped BLOCK on SYS NEVM soon (TM). 

I've got changes in the works for XQuery, exrproxy and payment-processor to further support SYS (eg: project payments in SYS or sysBLOCK) but they're not ready for PRs yet.  