### PR TITLE
Dynamic rpcthreads

### DIFF
--- a/autobuild/app.py
+++ b/autobuild/app.py
@@ -246,8 +246,8 @@ def processcustom(customlist, SUBNET, BRANCHPATH):
 		for i in to_del_index:
 			del c['daemons'][i]
 
-		if rpc_threads > 8:
-			c['rpcthreads'] = rpc_threads
+		if rpc_threads > 4:
+			c['rpcthreads'] = rpc_threads * 2
 		else:
 			c['rpcthreads'] = 8
 


### PR DESCRIPTION
desac actually included the requested change long ago but the issue wasn't closed.
I've tweaked it a bit to set rpcthreads to twice the number of XBridge wallets to give a bit of headroom.

closes #21 