### PR TITLE
Detail plugin info

### DIFF
--- a/autobuild/app.py
+++ b/autobuild/app.py
@@ -193,6 +193,7 @@ def processcustom(customlist, SUBNET, BRANCHPATH):
 
 				if name.upper() == 'HYDRA':
 					print('HYDRA exists')
+					customlist[0]['plugins'].append('evm_passthrough')
 					if 'free' in c['daemons'][i].keys() and c['daemons'][i]['free'] == True:
 						customlist[0]['plugins'].append('free_evm_passthrough')
 					for j in c['daemons'][i]['chains']:
@@ -205,6 +206,7 @@ def processcustom(customlist, SUBNET, BRANCHPATH):
 					customlist[0]['deploy_xquery'] = True
 					query = dict(c['daemons'][i])
 					del query['name']
+					customlist[0]['plugins'].append('xquery')
 					for xq_chain in query['chains']:
 						customlist[0]['plugins'].append(f'xquery_{xq_chain["name"].lower()}')
 					autoconfig.write_yaml_file('xquery.yaml',query)

--- a/autobuild/app.py
+++ b/autobuild/app.py
@@ -193,20 +193,20 @@ def processcustom(customlist, SUBNET, BRANCHPATH):
 
 				if name.upper() == 'HYDRA':
 					print('HYDRA exists')
-					if 'evm_passthrough' not in customlist[0]['plugins']:
-						customlist[0]['plugins'].append('evm_passthrough')
 					if 'free' in c['daemons'][i].keys() and c['daemons'][i]['free'] == True:
 						customlist[0]['plugins'].append('free_evm_passthrough')
 					for j in c['daemons'][i]['chains']:
 						print(f'HYDRA - {j["name"].upper()}')
 						customlist[0]['hydra'].append(j['name'].upper())
+						customlist[0]['plugins'].append(f'evm_passthrough_{j["name"].lower()}')
 					
 				if name.upper() == 'XQUERY':
 					print('XQUERY exists')
-					customlist[0]['plugins'].append('xquery')
 					customlist[0]['deploy_xquery'] = True
 					query = dict(c['daemons'][i])
 					del query['name']
+					for xq_chain in query['chains']:
+						customlist[0]['plugins'].append(f'xquery_{xq_chain["name"].lower()}')
 					autoconfig.write_yaml_file('xquery.yaml',query)
 					used_ip, qtemplate = xq_template(used_ip, SUBNET, query, customlist[0])
 					for key, item in qtemplate.items():

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -13,8 +13,8 @@ services:
       - 30303
     ports:
       - "8369:8369"
-      - "8545:8545"
-      - "30303:30303"
+      #- "8545:8545"
+      #- "30303:30303"
 {% endif %}
     entrypoint: /opt/blockchain/start-{{ daemon.configName }}.sh
     command:

--- a/autobuild/templates/xquery.j2
+++ b/autobuild/templates/xquery.j2
@@ -46,7 +46,7 @@
       DB_DATABASE: postgres
       ZMQ_GATEWAY_PORT1: {{ gateway_processor_port1 }}
       ZMQ_GATEWAY_PORT2: {{ gateway_processor_port2 }}
-    ports:
+    #ports:
       #- "{{ gateway_processor_port1 }}:{{ gateway_processor_port1 }}"
       #- "{{ gateway_processor_port2 }}:{{ gateway_processor_port2 }}"
     logging:

--- a/autobuild/templates/xquery.j2
+++ b/autobuild/templates/xquery.j2
@@ -47,8 +47,8 @@
       ZMQ_GATEWAY_PORT1: {{ gateway_processor_port1 }}
       ZMQ_GATEWAY_PORT2: {{ gateway_processor_port2 }}
     ports:
-      - "{{ gateway_processor_port1 }}:{{ gateway_processor_port1 }}"
-      - "{{ gateway_processor_port2 }}:{{ gateway_processor_port2 }}"
+      #- "{{ gateway_processor_port1 }}:{{ gateway_processor_port1 }}"
+      #- "{{ gateway_processor_port2 }}:{{ gateway_processor_port2 }}"
     logging:
       driver: "json-file"
       options:

--- a/plugins/evm_passthrough.conf
+++ b/plugins/evm_passthrough.conf
@@ -2,4 +2,4 @@ parameters=string,string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for EVM based blockchains with Hydra. Parameters are ["method", "[param1, param2, etc...]", "api-key=somekeyhere"]
+help=Query for EVM based blockchains with Hydra. See https://api.blocknet.co/#hydra-api

--- a/plugins/evm_passthrough_avax.conf
+++ b/plugins/evm_passthrough_avax.conf
@@ -1,0 +1,1 @@
+evm_passthrough.conf

--- a/plugins/evm_passthrough_eth.conf
+++ b/plugins/evm_passthrough_eth.conf
@@ -1,0 +1,1 @@
+evm_passthrough.conf

--- a/plugins/evm_passthrough_nevm.conf
+++ b/plugins/evm_passthrough_nevm.conf
@@ -1,0 +1,1 @@
+evm_passthrough.conf

--- a/plugins/xquery.conf
+++ b/plugins/xquery.conf
@@ -2,4 +2,4 @@ parameters=string,string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for indexed data provided by XQuery. Parameters are ["method", "[param1, param2, etc...]", "api-key=somekeyhere"]
+help=Query for indexed data provided by XQuery. See https://api.blocknet.co/#xquery-api

--- a/plugins/xquery_avax_pangolin.conf
+++ b/plugins/xquery_avax_pangolin.conf
@@ -1,0 +1,1 @@
+xquery.conf

--- a/plugins/xquery_eth_uniswap_v2.conf
+++ b/plugins/xquery_eth_uniswap_v2.conf
@@ -1,0 +1,1 @@
+xquery.conf

--- a/plugins/xquery_eth_uniswap_v3.conf
+++ b/plugins/xquery_eth_uniswap_v3.conf
@@ -1,0 +1,1 @@
+xquery.conf

--- a/plugins/xquery_nevm_pegasys.conf
+++ b/plugins/xquery_nevm_pegasys.conf
@@ -1,0 +1,1 @@
+xquery.conf


### PR DESCRIPTION
Currently, SNodes broadcast information about which services they support. This information is visible through the Blocknet wallet `servicenodestatus` command, and also publicly available through various means, including through lucien's Service Node Explorer.  Via the `servicenodestatus` command, the list of supported services looks something like this:

```json
[
  {
    "alias": "jamaica",
    "tier": "SPV",
    "snodekey": "03393fe1b3676935158d6ab633855d190b9a1a290c66f6aee8b3b20bb15a4ea58a",
    "snodeprivkey": "Po6RfAQgAdg9SJqLAWNBYyDZBEvkZfgpb56FJrc5KtsH1FZLxpaN",
    "address": "BTsuqMeFcHPnnV3BjRpTerFDftsruytmve",
    "timelastseen": 1656392177,
    "timelastseenstr": "2022-06-28T04:56:17.000Z",
    "status": "running",
    "services": [
      "BLOCK",
      "DASH",
      "GBX",
      "LTC",
      "MUE",
      "PHR",
      "PIVX",
      "RVN",
      "SYS",
      "xr",
      "xr::BLOCK",
      "xr::DASH",
      "xr::GBX",
      "xr::LTC",
      "xr::MUE",
      "xr::PHR",
      "xr::PIVX",
      "xr::RVN",
      "xr::SYS",
      "xrs::evm_passthrough",
      "xrs::projects",
      "xrs::xquery"
    ]
  }
]
```
This includes information that the SNode supports Hydra services:
```json
      "xrs::evm_passthrough",
```
and that it supports XQuery services:
```json
      "xrs::xquery"
```
but it's missing critical information about *which EVM chains* are supported by Hydra & XQuery.
This PR fixes that problem. After deploying an SNode with the changes included in this PR, the `servicenodestatus` command returns details like this:
```json
[
  {
    "alias": "aruba",
    "tier": "SPV",
    "snodekey": "02a5d0279e484a3df81acd611e1052d2e0797e796564ecbc25c7fe19f36e9985e5",
    "snodeprivkey": "PswGMd6faZf1ceLojzGeKn7PQuXVwYgRQG8obUKrThZ8ap4pkRR7",
    "address": "BqNaZmLJe9wEGBHDNid9FvsgrG2x7Hbfex",
    "timelastseen": 1656392219,
    "timelastseenstr": "2022-06-28T04:56:59.000Z",
    "status": "running",
    "services": [
      "BLOCK",
      "GBX",
      "MUE",
      "PHR",
      "PIVX",
      "SCC",
      "SYS",
      "xr",
      "xr::BLOCK",
      "xr::GBX",
      "xr::MUE",
      "xr::PHR",
      "xr::PIVX",
      "xr::SCC",
      "xr::SYS",
      "xrs::evm_passthrough",
      "xrs::evm_passthrough_eth",
      "xrs::evm_passthrough_nevm",
      "xrs::projects",
      "xrs::xquery",
      "xrs::xquery_nevm_pegasys"
    ]
  }
]
```
Note the details of SNode services now include *which EVM chains are supported by Hydra*:
```json
      "xrs::evm_passthrough_eth",
      "xrs::evm_passthrough_nevm",
```
and *which EVM chains/routers are supported by XQuery*:
```json
      "xrs::xquery_nevm_pegasys"
```
The fact that this information is publicly broadcast by each SNode means it can be discovered by the Service Node Explorer. So, for example, if a client wants to find all Service Nodes which support XQuery services specifically for the NEVM chain, they can look here: https://service-explorer.core.cloudchainsinc.com/#/xcloud-services/nodes/xrs::xquery_nevm_pegasys

Or if they want to find an SNode which supports Hydra access to ETH, they could look here:
https://service-explorer.core.cloudchainsinc.com/#/xcloud-services/nodes/xrs::evm_passthrough_eth

Note, it's also still possible to use the Service Node Explorer to search for all SNodes supporting Hydra *in general* - with no requirements for a specific EVM to be supported:
https://service-explorer.core.cloudchainsinc.com/#/xcloud-services/nodes/xrs::evm_passthrough
...and it's also still possible to use the Service Node Explorer to search for all SNodes supporting XQuery *in general* - with no requirements for a specific EVM to be supported:
https://service-explorer.core.cloudchainsinc.com/#/xcloud-services/nodes/xrs::xquery

These changes have been tested and they don't break methods currently used to access Hydra and XQuery.

Note, I'll update the API docs to include information on how to search for SNodes which support the exact services & EVMs the client is looking for.