### PR TITLE
Bump dash

### DIFF
--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -49,7 +49,7 @@
   type: chain
   image: blocknetdx/bitcoin:v0.20.0
   volume: /snode
-  disk: 500
+  disk: 550
   ram: 5
   cpu: 4
 
@@ -57,7 +57,7 @@
   type: chain
   image: blocknetdx/dash:v0.17.0.3
   volume: /snode
-  disk: 37
+  disk: 38
   ram: 6
   cpu: 4
 
@@ -65,7 +65,7 @@
   type: chain
   image: blocknetdx/digibyte:v7.17.2
   volume: /snode
-  disk: 33
+  disk: 34
   ram: 5
   cpu: 4
 
@@ -73,7 +73,7 @@
   type: chain
   image: blocknetdx/dogecoin:v1.14.5
   volume: /snode
-  disk: 63
+  disk: 68
   ram: 5
   cpu: 4
 
@@ -97,7 +97,7 @@
   type: chain
   image: blocknetdx/lbrycredits:v0.17.4.6
   volume: /snode
-  disk: 150
+  disk: 160
   ram: 5
   cpu: 4
 
@@ -105,7 +105,7 @@
   type: chain
   image: blocknetdx/litecoin:v0.18.1
   volume: /snode
-  disk: 85
+  disk: 100
   ram: 5
   cpu: 4
 
@@ -137,7 +137,7 @@
   type: chain
   image: blocknetdx/ravencoin:v4.3.2.1
   volume: /snode
-  disk: 31
+  disk: 36
   ram: 5
   cpu: 4
 
@@ -153,7 +153,15 @@
   type: hybrid
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
-  disk: 9
+  disk: 11
+  ram: 5
+  cpu: 4
+
+- name: UNO 
+  type: chain
+  image: blocknetdx/unobtanium:v0.11.5
+  volume: /snode
+  disk: 5
   ram: 5
   cpu: 4
 
@@ -161,16 +169,7 @@
   type: evm_chain
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
-  disk: 9
-  ram: 5
-  cpu: 4
-
-
-- name: UNO 
-  type: chain
-  image: blocknetdx/unobtanium:v0.11.5
-  volume: /snode
-  disk: 5
+  disk: 11
   ram: 5
   cpu: 4
 

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -55,7 +55,7 @@
 
 - name: DASH 
   type: chain
-  image: blocknetdx/dash:v0.17.0.3
+  image: blocknetdx/dash:latest
   volume: /snode
   disk: 38
   ram: 6

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -11,11 +11,9 @@ services:
 {% if deploy_nevm and daemon.name == 'SYS' %}
       - 8545
       - 30303
-    ports:
-      - "8369:8369"
-      #- "8545:8545"
-      #- "30303:30303"
 {% endif %}
+    ports:
+      - "{{ daemon.p2pPort }}:{{ daemon.p2pPort }}"
     entrypoint: /opt/blockchain/start-{{ daemon.configName }}.sh
     command:
       - {{ daemon.binFile }}


### PR DESCRIPTION
DASH had a mandatory upgrade to 18.0.1 on 17 August 2022.

This PR also updates the on-disk space requirements for several chains and adds a `ports` line for each wallet so it will accept inbound P2P connections.