### PR TITLE
include fix to collections bug on update; also cleaned code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xquery.yaml
 .known_volumes
 .cache
 .cache_ip
+.python-version

--- a/exr_env.sh
+++ b/exr_env.sh
@@ -254,7 +254,7 @@ Help()
 # Process the input options. Add options as needed.        #
 ############################################################
 # Get the options
-VALID_ARGS=$(getopt -o hougdpvb: --long help,update,version,builder: -- "$@")
+VALID_ARGS=$(getopt -o huvb: --long help,update,version,builder: -- "$@")
 if [[ $? -ne 0 ]]; then
 	exit 1;
 fi


### PR DESCRIPTION
Add the auto-fix for the collections bug to the `exr_env.sh` tool when the `-u` or `--update` param is passed. This could help someone who installed EXR env using a version of the global install script which did *not* fix this bug on installation or set up pyenv to run an earlier version of python within the `~/exrproxy-env` directory.

The changes in this PR have been tested.