### PR TITLE
Don't double count SYS disk

### DIFF
--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -169,7 +169,7 @@
   type: evm_chain
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
-  disk: 11
+  disk: 0
   ram: 5
   cpu: 4
 


### PR DESCRIPTION
Conan🔀 — Today at 03:05
@walkjivefly When builder.py calculates the total disk space required, it adds the amount required for SYS and the amount required for NEVM. (See image below.)  If both SYS and NEVM have a requirement of 11 GB, and the SNode op deploys both SYS and NEVM, it will calculate the total requirement for the two of them as 11 GB + 11 GB = 22 GB. I think we should set the disk requirement for NEVM as 0 GB. This should be correct for both internal and external NEVM, because additional disk required for NEVM is 0 in both cases.
Image

