### PR TITLE
Feature/rebased utxo

### DIFF
--- a/autobuild/app.py
+++ b/autobuild/app.py
@@ -24,7 +24,7 @@ J2_ENV2 = Environment(loader=BaseLoader(),
 
 OUTPUT_PATH = './'
 IPS_CACHE = '.cache_ip'
-UTXO_PLUGIN_METHODS = ['getutxos','getrawtransaction','getrawmempool','getblockcount','sendrawtransaction','gettransaction','getblock','getblockhash','heights','fees','getbalance','gethistory','ping']
+UTXO_PLUGIN_METHODS = ['getutxos','getrawtransaction','getrawmempool','getblockcount','sendrawtransaction','gettransaction','getblock','getblockhash','heights','fees','getbalance','getaddresshistory','ping']
 
 def processcustom(customlist, SUBNET, BRANCHPATH):
 	if IPS_CACHE not in os.listdir(os.getcwd()):

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -169,7 +169,7 @@
   type: evm_chain
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
-  disk: 9
+  disk: 11
   ram: 5
   cpu: 4
 

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -177,6 +177,9 @@
   type: utxo_plugin
   utxo_plugin_image: blocknetdx/utxo-plugin:latest
   plugin_adapter_image: blocknetdx/plugin-adapter:latest
+  exclude_chains: # The utxo-plugin module doesn't yet work for the following chains:
+    - PHR
+    - LBC
   volume: /snode
   disk: 200
   ram: 32

--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -169,9 +169,18 @@
   type: evm_chain
   image: blocknetdx/syscoin4:v4.3.0
   volume: /snode
-  disk: 0
+  disk: 9
   ram: 5
   cpu: 4
+
+- name: UTXO_PLUGIN
+  type: utxo_plugin
+  utxo_plugin_image: blocknetdx/utxo-plugin:latest
+  plugin_adapter_image: blocknetdx/plugin-adapter:latest
+  volume: /snode
+  disk: 200
+  ram: 32
+  cpu: 8
 
 - name: HYDRA
   type: app

--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -20,7 +20,7 @@ services:
     environment:
       RPC_USER: "${RPC_USER}"
       RPC_PASSWORD: "${RPC_PASSWORD}"
-      RPC_ALLOWIP: 172.31.0.0/20
+      RPC_ALLOWIP: {{ subnet }}
     stop_signal: SIGINT
 {% if daemon.name == 'SYS' %}
     stop_grace_period: 20m
@@ -325,13 +325,31 @@ services:
       backend:
         ipv4_address: {{ xr_proxy_ip }}
 
-#### XQUERY ####
+{% if False %}
+#### EXCLUDE_FROM_VARIABLE_INFER ####
+{% endif %}
+
 {% if deploy_xquery %}
+#### START XQUERY STACK ####
 
 {% include 'autobuild/templates/xquery.j2' %}
 
+
+#### END XQUERY STACK ####
 {% endif %}
-#### XQUERY ####
+
+{% if deploy_utxo %}
+#### START UTXO STACK ####
+
+{% include 'autobuild/templates/utxo.j2' %}
+
+
+#### END UTXO STACK ####
+{% endif %}
+
+{% if False %}
+#### EXCLUDE_FROM_VARIABLE_INFER ####
+{% endif %}
 
 networks:
   frontend:
@@ -348,7 +366,7 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.31.0.0/20
+        - subnet: {{ subnet }}
     driver_opts:
       com.docker.network.bridge.enable_icc: "true"
       com.docker.network.bridge.enable_ip_masquerade: "true"

--- a/autobuild/templates/utxo.j2
+++ b/autobuild/templates/utxo.j2
@@ -17,7 +17,7 @@
     stop_signal: SIGINT
     stop_grace_period: 5m
     volumes:
-      - {{ utxo_plugin_volume }}/utxoplugin-db/{{ chain.name.upper() }}:/app/plugins/utxoplugin-{{ chain.name.upper() }}
+      - {{ utxo_plugin_volume }}/utxo_plugin/{{ chain.name.upper() }}:/app/plugins/utxoplugin-{{ chain.name.upper() }}
     logging:
       driver: "json-file"
       options:

--- a/autobuild/templates/utxo.j2
+++ b/autobuild/templates/utxo.j2
@@ -1,0 +1,52 @@
+{% for chain in full_utxo_plugin_chains %}
+
+  utxo-plugin-{{ chain.name.upper() }}:
+    image: {{ utxo_plugin_image }}
+    restart: unless-stopped 
+    environment:
+      PLUGIN_COIN: {{ chain.name.upper() }}
+      PLUGIN_PORT: 8000
+      DB_ENGINE: 'rocksdb'
+      NETWORK: 'mainnet'
+      SKIP_COMPACT: 'true'
+      DAEMON_ADDR: {{ chain.daemon_addr }}
+      DAEMON_RPC_PORT: {{ chain.rpc_port }}
+      RPC_USER: "${RPC_USER}"
+      RPC_PASSWORD: "${RPC_PASSWORD}"
+      RPC_ALLOWIP: {{ subnet }}
+    stop_signal: SIGINT
+    stop_grace_period: 5m
+    volumes:
+      - {{ utxo_plugin_volume }}/utxoplugin-db/{{ chain.name.upper() }}:/app/plugins/utxoplugin-{{ chain.name.upper() }}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "2m"
+        max-file: "10"
+    depends_on:
+      - {{ chain.depends_on }}
+    networks:
+      backend:
+        ipv4_address: {{ chain.ip }}
+
+{% endfor %}
+
+  plugin-adapter:
+    image: {{ plugin_adapter_image }}
+    restart: unless-stopped
+    environment:
+      UTXO_PLUGIN_LIST: {{ adapter_utxo_plugin_list }}
+    stop_signal: SIGINT
+    stop_grace_period: 5m
+    depends_on:
+{% for chain in full_utxo_plugin_chains %}
+      - utxo-plugin-{{ chain.name }}
+{% endfor %}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "2m"
+        max-file: "10"
+    networks:
+      backend:
+        ipv4_address: {{ plugin_adapter_ip }}

--- a/autobuild/templates/xrproxy.j2
+++ b/autobuild/templates/xrproxy.j2
@@ -67,6 +67,19 @@ set-ph = XQUERY_IP={{ reverse_proxy_ip }}
 set-ph = XQUERY_PORT={{ reverse_proxy_port }}
 {% endif %}
 
+{% if deploy_utxo %}
+{% for utxo_plugin_method in utxo_plugin_methods %}
+
+set-ph = RPC_getutxos_HOSTIP=plugin-adapter
+set-ph = RPC_getutxos_PORT=5000
+set-ph = RPC_getutxos_USER=${RPC_USER}
+set-ph = RPC_getutxos_PASS=${RPC_PASSWORD}
+set-ph = RPC_getutxos_METHOD={{ utxo_plugin_method }}
+
+{% endfor %}
+{% endif %}
+
+
 EOL
 # ensure supervisord runs at pid1
 exec supervisord -c /etc/supervisord.conf

--- a/autobuild/templates/xrproxy.j2
+++ b/autobuild/templates/xrproxy.j2
@@ -70,11 +70,11 @@ set-ph = XQUERY_PORT={{ reverse_proxy_port }}
 {% if deploy_utxo %}
 {% for utxo_plugin_method in utxo_plugin_methods %}
 
-set-ph = RPC_getutxos_HOSTIP=plugin-adapter
-set-ph = RPC_getutxos_PORT=5000
-set-ph = RPC_getutxos_USER=${RPC_USER}
-set-ph = RPC_getutxos_PASS=${RPC_PASSWORD}
-set-ph = RPC_getutxos_METHOD={{ utxo_plugin_method }}
+set-ph = RPC_{{ utxo_plugin_method }}_HOSTIP=plugin-adapter
+set-ph = RPC_{{ utxo_plugin_method }}_PORT=5000
+set-ph = RPC_{{ utxo_plugin_method }}_USER=${RPC_USER}
+set-ph = RPC_{{ utxo_plugin_method }}_PASS=${RPC_PASSWORD}
+set-ph = RPC_{{ utxo_plugin_method }}_METHOD={{ utxo_plugin_method }}
 
 {% endfor %}
 {% endif %}

--- a/autobuild/utils/__init__.py
+++ b/autobuild/utils/__init__.py
@@ -1,3 +1,4 @@
+import re
 from rich import print
 from rich.table import Table
 import math
@@ -29,7 +30,7 @@ input_template_args = [{
 	'deploy_eth': False,
 	'gethexternal': False,
 	'eth_testnet': False,
-	'syncmode': 'light'
+	'syncmode': 'full'
 }]
 
 
@@ -105,6 +106,12 @@ class Snode():
 		self.inquirer = Inquirer()
 		self.envfile = envfile
 		self.config = dotenv.dotenv_values(self.envfile)
+		get_utxo_plugin_code_response = requests.get('https://raw.githubusercontent.com/blocknetdx/utxo-plugin/main/main.py')
+		if get_utxo_plugin_code_response.status_code != 200:
+			raise Exception("EROR: Failed to get list of supported UTXO Plugin chains from https://raw.githubusercontent.com/blocknetdx/utxo-plugin/main/main.py.")
+		coin_map = re.search("coin_map([^}]|\n)+}", get_utxo_plugin_code_response.text)
+		self.supported_utxo_plugin_chains = re.findall(r"\"(.+)\"", coin_map.group())
+		#print("Supported UTXO Plugin Chains: ", self.supported_utxo_plugin_chains)
 
 	def get_sudo(self):
 		granted = False

--- a/autobuild/utils/autoconfig.py
+++ b/autobuild/utils/autoconfig.py
@@ -65,7 +65,7 @@ def template_vars(template_path):
     #jinja2 all variables
     with open(template_path) as file:
         contents = file.read()
-        contents = str(contents.split('#### XQUERY ####')[0])+str(contents.split('#### XQUERY ####')[-1])
+        contents = str(contents.split('#### EXCLUDE_FROM_VARIABLE_INFER ####')[0])+str(contents.split('#### EXCLUDE_FROM_VARIABLE_INFER ####')[-1])
         variables = jinja2schema.infer(contents)
         variables = jinja2schema.to_json_schema(variables)
         if 'chainstate_mount_dir' in variables['properties']['daemons']['items']['required']:

--- a/autobuild/utils/utxo.py
+++ b/autobuild/utils/utxo.py
@@ -1,0 +1,42 @@
+from rich import print
+from autobuild.utils.autoconfig import random_ip
+
+def utxo_template(used_ip, subnet, utxo_plugin, data):
+
+	# create dictionary to access utxo coin RPC port and container IP address
+	utxo_coin_dict = {'BLOCK':{'ip':data['snode_ip'],'rpc_port':'41414'}}
+	utxo_coins = [x['name'] for x in utxo_plugin['chains']]
+	for daemon in data['daemons']:
+		if daemon['name'] in utxo_coins:
+			utxo_coin_dict[daemon['name']] = {'ip':daemon['ip'], 'rpc_port':daemon['rpcPort']}
+
+	# prepare data to fill in utxo plugin container data in autobuild/templates/utxo.j2
+#	print("utxo_coin_dict: ", utxo_coin_dict)
+#	print("utxo_plugin: ", utxo_plugin)
+#	print("data: ", data)
+	final_data = {}
+	final_data['full_utxo_plugin_chains'] = []
+	utxo_container_ip = {}
+	for coin_name in utxo_coins:
+		utxo_plugin_chain = {'name':coin_name}
+		ip_name = f'{coin_name.lower()}_utxo_plugin_ip'
+		custom_ip = random_ip(subnet)
+		if ip_name in used_ip['ip'].keys():
+			utxo_plugin_chain['ip'] = used_ip['ip'][ip_name]
+		else:
+			while True:
+				custom_ip = random_ip(subnet)
+				if custom_ip not in used_ip['ip'].values():
+					utxo_plugin_chain['ip'] = custom_ip
+					used_ip['ip'][ip_name] = custom_ip
+					break
+		utxo_container_ip[coin_name] = utxo_plugin_chain['ip']
+		utxo_plugin_chain['rpc_port'] = utxo_coin_dict[coin_name]['rpc_port']
+		utxo_plugin_chain['daemon_addr'] = utxo_coin_dict[coin_name]['ip']
+		utxo_plugin_chain['depends_on'] = coin_name if coin_name != 'BLOCK' else 'snode'
+		final_data['full_utxo_plugin_chains'].append(utxo_plugin_chain)
+
+	# prepare data to fill in plugin adapter container data in autobuild/templates/utxo.j2
+	final_data['adapter_utxo_plugin_list'] = ','.join([f'{coin_name}:{utxo_container_ip[coin_name]}' for coin_name in utxo_coins])
+
+	return [used_ip, final_data]

--- a/builder.py
+++ b/builder.py
@@ -160,7 +160,7 @@ if __name__ == '__main__':
 						if c['name'] in known_volumes['volumes'].keys():
 							c['volume'] = known_volumes['volumes'][c['name']]
 						input_template[0]['daemons'].append(c)
-						if c['name'] in snode.supported_utxo_plugin_chains:
+						if c['name'] in snode.supported_utxo_plugin_chains and c['name'] not in utxo_plugins[0]['exclude_chains']:
 							utxo_plugins_todeploy.append(c['name'])
 
 			print(f"[bold magenta]{'-'*50}[/bold magenta]")	
@@ -262,7 +262,7 @@ if __name__ == '__main__':
 				elif any([[True for x in [deploy['name'] for deploy in input_template[0]['daemons']] if x==xx] for xx in [echain['name'] for echain in evm_chains]]):
 					input_template[0]['daemons'].append(b)
 
-			if snode_in_base:
+			if snode_in_base: # this flag true if SNODE deployed (not TNODE, TESTSNODE or TESTTNODE)
 				# Add support for utxo plugins
 				# This section must be AFTER SNODE is appended to input_template[0]['daemons'] so SNODE container gets assigned an IP address BEFORE utxo plugin containers are constructed
 				print(f"[bold magenta]{'-'*50}[/bold magenta]")	

--- a/plugins/fees.conf
+++ b/plugins/fees.conf
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns transaction fees for all utxo coins supported by the responding server. Usage: fees
-=======
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/fees.conf
+++ b/plugins/fees.conf
@@ -1,5 +1,5 @@
-parameters=string,string
+parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Returns transaction fees for all utxo coins supported by the responding server. Usage: fees

--- a/plugins/fees.conf
+++ b/plugins/fees.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/fees.conf
+++ b/plugins/fees.conf
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns transaction fees for all utxo coins supported by the responding server. Usage: fees
+=======
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getaddresshistory.conf
+++ b/plugins/getaddresshistory.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for hist of transactions of given chain at given addresses. Usage: getaddresshistory [chain-ticker] [comma-separated-list-of-addresses]

--- a/plugins/getbalance.conf
+++ b/plugins/getbalance.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for balance of given coin at given addresses. Usage: getbalance [coin] [addresses]
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getbalance.conf
+++ b/plugins/getbalance.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getbalance.conf
+++ b/plugins/getbalance.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for balance of given coin at given addresses. Usage: getbalance [coin] [addresses]

--- a/plugins/getbalance.conf
+++ b/plugins/getbalance.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for balance of given coin at given addresses. Usage: getbalance [coin] [addresses]
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblock.conf
+++ b/plugins/getblock.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for block data of given chain at given block hash. Usage: getblock [chain-ticker] [block-hash] (optional 3rd param of "True" for verbose response)

--- a/plugins/getblock.conf
+++ b/plugins/getblock.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for block data of given chain at given block hash. Usage: getblock [chain-ticker] [block-hash] (optional 3rd param of "True" for verbose response)
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblock.conf
+++ b/plugins/getblock.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getblock.conf
+++ b/plugins/getblock.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for block data of given chain at given block hash. Usage: getblock [chain-ticker] [block-hash] (optional 3rd param of "True" for verbose response)
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblockcount.conf
+++ b/plugins/getblockcount.conf
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Query for block count of given chain. Usage: getblockcount [chain-ticker]
+=======
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblockcount.conf
+++ b/plugins/getblockcount.conf
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Query for block count of given chain. Usage: getblockcount [chain-ticker]
-=======
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblockcount.conf
+++ b/plugins/getblockcount.conf
@@ -1,5 +1,5 @@
-parameters=string,string
+parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for block count of given chain. Usage: getblockcount [chain-ticker]

--- a/plugins/getblockcount.conf
+++ b/plugins/getblockcount.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getblockhash.conf
+++ b/plugins/getblockhash.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for block hash of given chain at given block height. Usage: getblockhash [chain-ticker] [block-height]
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblockhash.conf
+++ b/plugins/getblockhash.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getblockhash.conf
+++ b/plugins/getblockhash.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for block hash of given chain at given block height. Usage: getblockhash [chain-ticker] [block-height]
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getblockhash.conf
+++ b/plugins/getblockhash.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for block hash of given chain at given block height. Usage: getblockhash [chain-ticker] [block-height]

--- a/plugins/gethistory.conf
+++ b/plugins/gethistory.conf
@@ -1,9 +1,0 @@
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-<<<<<<< HEAD
-help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [chain-ticker] [comma-separated-list-of-addresses]
-=======
-help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/gethistory.conf
+++ b/plugins/gethistory.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [utxo-chain] [[list-of-addresses]]

--- a/plugins/gethistory.conf
+++ b/plugins/gethistory.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [chain-ticker] [comma-separated-list-of-addresses]
+=======
+help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/gethistory.conf
+++ b/plugins/gethistory.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [utxo-chain] [[list-of-addresses]]
+help=Query for hist of transactions of given chain at given addresses. Usage: gethistory [chain-ticker] [comma-separated-list-of-addresses]

--- a/plugins/getrawmempool.conf
+++ b/plugins/getrawmempool.conf
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Query for rawmempool data of given chain. Usage: getrawmempool [chain-ticker] (optional 2nd param of "True" for verbose response)
+=======
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getrawmempool.conf
+++ b/plugins/getrawmempool.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getrawmempool.conf
+++ b/plugins/getrawmempool.conf
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Query for rawmempool data of given chain. Usage: getrawmempool [chain-ticker] (optional 2nd param of "True" for verbose response)
-=======
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getrawmempool.conf
+++ b/plugins/getrawmempool.conf
@@ -1,5 +1,5 @@
-parameters=string,string
+parameters=string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for rawmempool data of given chain. Usage: getrawmempool [chain-ticker] (optional 2nd param of "True" for verbose response)

--- a/plugins/getrawtransaction.conf
+++ b/plugins/getrawtransaction.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for raw transaction data on given chain for given transaction id. Usage: getrawtransaction [chain-ticker] [transaction-id] (optional 3rd param of "True" for verbose response)
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getrawtransaction.conf
+++ b/plugins/getrawtransaction.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getrawtransaction.conf
+++ b/plugins/getrawtransaction.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for raw transaction data on given chain for given transaction id. Usage: getrawtransaction [chain-ticker] [transaction-id] (optional 3rd param of "True" for verbose response)
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getrawtransaction.conf
+++ b/plugins/getrawtransaction.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for raw transaction data on given chain for given transaction id. Usage: getrawtransaction [chain-ticker] [transaction-id] (optional 3rd param of "True" for verbose response)

--- a/plugins/gettransaction.conf
+++ b/plugins/gettransaction.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for transaction data on given chain for given transaction id. Usage: gettransaction [chain-ticker] [transaction-id]
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/gettransaction.conf
+++ b/plugins/gettransaction.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for transaction data on given chain for given transaction id. Usage: gettransaction [chain-ticker] [transaction-id]
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/gettransaction.conf
+++ b/plugins/gettransaction.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/gettransaction.conf
+++ b/plugins/gettransaction.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for transaction data on given chain for given transaction id. Usage: gettransaction [chain-ticker] [transaction-id]

--- a/plugins/getutxos.conf
+++ b/plugins/getutxos.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Query for list of utxos on given chain at given addresses. Usage: getutxos [chain-ticker] [comma-separated-list-of-addresses]
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/getutxos.conf
+++ b/plugins/getutxos.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/getutxos.conf
+++ b/plugins/getutxos.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Query for list of utxos on given chain at given addresses. Usage: getutxos [chain-ticker] [comma-separated-list-of-addresses]

--- a/plugins/getutxos.conf
+++ b/plugins/getutxos.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Query for list of utxos on given chain at given addresses. Usage: getutxos [chain-ticker] [comma-separated-list-of-addresses]
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/heights.conf
+++ b/plugins/heights.conf
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns block heights of all utxo coins supported by the responding server. Usage: heights
+=======
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/heights.conf
+++ b/plugins/heights.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/heights.conf
+++ b/plugins/heights.conf
@@ -1,5 +1,5 @@
-parameters=string,string
+parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Returns block heights of all utxo coins supported by the responding server. Usage: heights

--- a/plugins/heights.conf
+++ b/plugins/heights.conf
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns block heights of all utxo coins supported by the responding server. Usage: heights
-=======
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/ping.conf
+++ b/plugins/ping.conf
@@ -1,5 +1,5 @@
-parameters=string,string
+parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Returns {"reply": 1, "uuid": <uuid>} if server is alive. Usage: ping

--- a/plugins/ping.conf
+++ b/plugins/ping.conf
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns {"reply": 1, "uuid": <uuid>} if server is alive. Usage: ping
-=======
-parameters=string,string
-fee=0
-clientrequestlimit=50
-disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/ping.conf
+++ b/plugins/ping.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/ping.conf
+++ b/plugins/ping.conf
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 parameters=
 fee=0
 clientrequestlimit=50
 disabled=0
 help=Returns {"reply": 1, "uuid": <uuid>} if server is alive. Usage: ping
+=======
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/sendrawtransaction.conf
+++ b/plugins/sendrawtransaction.conf
@@ -2,4 +2,8 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
+<<<<<<< HEAD
 help=Broadcast raw transaction data on given chain. Usage: sendrawtransaction [chain-ticker] [raw-transaction]
+=======
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+>>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/sendrawtransaction.conf
+++ b/plugins/sendrawtransaction.conf
@@ -2,8 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-<<<<<<< HEAD
 help=Broadcast raw transaction data on given chain. Usage: sendrawtransaction [chain-ticker] [raw-transaction]
-=======
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
->>>>>>> 91b2175 (added option to builder to deploy support for utxo plugins)

--- a/plugins/sendrawtransaction.conf
+++ b/plugins/sendrawtransaction.conf
@@ -1,0 +1,5 @@
+parameters=string,string
+fee=0
+clientrequestlimit=50
+disabled=0
+help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]

--- a/plugins/sendrawtransaction.conf
+++ b/plugins/sendrawtransaction.conf
@@ -2,4 +2,4 @@ parameters=string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for list of utxos of given chain at given addresses. Usage: getutxos [utxo-chain] [[list-of-addresses]]
+help=Broadcast raw transaction data on given chain. Usage: sendrawtransaction [chain-ticker] [raw-transaction]


### PR DESCRIPTION
This PR adds a feature to the SNode builder tools which allows them to deploy support for `utxo-plugin` functionality.  This `utxo-plugin` support is required for an SNode to support the backend of XLite.

There are likely still fixes/enhancements needed in the `utxo-plugin` and/or `plugin-adapter` repos to fully support this feature, but afaik, the work in this PR is complete and bug free in terms of what's needed in this `exrproxy-env` repo to support this feature.

Afaik, there is no harm in merging this PR, even though `utxo-plugin` and/or `plugin-adapter` repos may still need some mods. 