### PR TITLE
added RVN & DGB to non-working utxos + .co => .org

### DIFF
--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -181,6 +181,8 @@
   exclude_chains: # The utxo-plugin module doesn't yet work for the following chains:
     - PHR
     - LBC
+    - RVN
+    - DGB
   volume: /snode
   disk: 200
   ram: 32

--- a/plugins/evm_passthrough.conf
+++ b/plugins/evm_passthrough.conf
@@ -2,4 +2,4 @@ parameters=string,string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for EVM based blockchains with Hydra. See https://api.blocknet.co/#hydra-api
+help=Query for EVM based blockchains with Hydra. See https://api.blocknet.org/#hydra-api

--- a/plugins/xquery.conf
+++ b/plugins/xquery.conf
@@ -2,4 +2,4 @@ parameters=string,string,string
 fee=0
 clientrequestlimit=50
 disabled=0
-help=Query for indexed data provided by XQuery. See https://api.blocknet.co/#xquery-api
+help=Query for indexed data provided by XQuery. See https://api.blocknet.org/#xquery-api


### PR DESCRIPTION
This PR adds RVN and DGB to the list of chains that don't currently work with utxo plugin indexing for some reason. It also updates all references to `api.blocknet.co` found in `exrproxy-env/plugins/*.conf` to point instead to `api.blocknet.org`