### PR TITLE
Stop docker containers in parallel by docker-compose down

### DIFF
--- a/autobuild/templates/dockercompose.j2
+++ b/autobuild/templates/dockercompose.j2
@@ -358,9 +358,3 @@ networks:
     driver_opts:
       com.docker.network.bridge.enable_icc: "true"
       com.docker.network.bridge.enable_ip_masquerade: "true"
-
-{% if deploy_xquery %}
-# volume for XQUERY:
-volumes:
-  alembic-versions:
-{% endif %}

--- a/autobuild/templates/xquery.j2
+++ b/autobuild/templates/xquery.j2
@@ -24,7 +24,7 @@
       ALEMBIC_SLEEP: {{ dex.alembic_sleep }} # Each xq-engine sleeps different time before running alembic - avoids db contention
       HASURA_IP: {{ hasura_ip }}
     volumes:
-      - alembic-versions:/app/xq-engine/alembic/versions
+      - {{ xquery_volume }}/xq/alembic:/app/xq-engine/alembic/versions
     logging:
       driver: "json-file"
       options:
@@ -41,7 +41,7 @@
     shm_size: 1g
     restart: unless-stopped
     volumes:
-      - {{ xquery_volume }}/xq:/var/lib/postgresql/data
+      - {{ xquery_volume }}/xq/db:/var/lib/postgresql/data
     tty: true
     environment:
       POSTGRES_USER: postgres

--- a/autobuild/utils/xquery.py
+++ b/autobuild/utils/xquery.py
@@ -18,7 +18,7 @@ def xq_template(used_ip, subnet, query, data):
 			redis_db = 0
 			for item in item0:
 				item['redis_db'] = redis_db
-				item['alembic_sleep'] = int(redis_db * 15) # make sure two xq-engine containers don't run alembic concurrently
+				item['alembic_sleep'] = int(redis_db * 60) # make sure two xq-engine containers don't run alembic concurrently
 				redis_db += 1
 				name = item['name'].upper()
 				if 'AVAX' in name:

--- a/builder.py
+++ b/builder.py
@@ -48,7 +48,6 @@ parser.add_argument('--deploy', help='Autodeploy stack', default=False, action='
 parser.add_argument('--prune', help='Prune docker', default=False, action='store_true')
 parser.add_argument('--source', help='Source file', default='autobuild/sources.yaml')
 parser.add_argument('--yaml', help='Custom input yaml', default=False)
-parser.add_argument('--interval', help='Docker stopping interval till sends SIGKILL signal; default 30s', default=30)
 parser.add_argument('--branchpath', default='https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master')
 parser.add_argument('--xquerytag', help="Override XQuery images tag", default='latest')
 parser.add_argument('--prunecache', help='Reinit .known_hosts, .known_volumes, .env and .cache files', action='store_true')
@@ -64,7 +63,6 @@ PRUNE = args.prune
 BRANCHPATH = re.sub(r'(^(?!.*/$).*)',r'\1/',args.branchpath)
 
 XQUERYTAG = args.xquerytag
-STOP_INTERVAL = int(args.interval)
 PRUNE_CACHE = args.prunecache
 SUBNET = args.subnet
 
@@ -125,7 +123,7 @@ if __name__ == '__main__':
 		# Requirements checks
 		if not CHECKS:
 			print(f"[bold magenta]{'-'*50}[/bold magenta]")
-			snode.checks(STOP_INTERVAL)
+			snode.checks()
 		# Set env vars
 		if not ENV:
 			print(f"[bold magenta]{'-'*50}[/bold magenta]")


### PR DESCRIPTION
Closes https://github.com/blocknetdx/exrproxy-env/issues/213

When `builder.py` detects docker containers already running in the `exrproxy-env` dir, it offers to stop them and clean up the docker environment before configuring the new set of services to deploy. This is useful in case the SNode Op wants to remove some services and add others. Previous to this PR, stopping all docker containers was done serially, which can take a long time for many containers. It was also done without leveraging the `docker-compose down` tool which stops all containers in an intelligent way. `docker-compose down` respects each individual container's `stop_grace_period` and dependencies as they are defined in docker-compose.yml. It also stops as many container as it can in parallel (without violating dependencies). This PR leverages `docker-compose down` to achieve all these benefits.