### PR TITLE
update xquery disk size req & disk location

### DIFF
--- a/autobuild/sources.yaml
+++ b/autobuild/sources.yaml
@@ -202,7 +202,7 @@
 - name: XQUERY
   type: app
   volume: /snode
-  disk: 5
+  disk: 15
   ram: 16
   cpu: 32
   dexs:

--- a/autobuild/templates/xquery.j2
+++ b/autobuild/templates/xquery.j2
@@ -24,7 +24,7 @@
       ALEMBIC_SLEEP: {{ dex.alembic_sleep }} # Each xq-engine sleeps different time before running alembic - avoids db contention
       HASURA_IP: {{ hasura_ip }}
     volumes:
-      - {{ xquery_volume }}/xq/alembic:/app/xq-engine/alembic/versions
+      - {{ xquery_volume }}/xquery/alembic:/app/xq-engine/alembic/versions
     logging:
       driver: "json-file"
       options:
@@ -41,7 +41,7 @@
     shm_size: 1g
     restart: unless-stopped
     volumes:
-      - {{ xquery_volume }}/xq/db:/var/lib/postgresql/data
+      - {{ xquery_volume }}/xquery/db:/var/lib/postgresql/data
     tty: true
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
Minor updates to xquery v2 disk space requirement and location where XQuery data and schema info are stored. This fixes an issue where `builder.py` was not calculating disk space requirements for XQuery correctly.