### PR TITLE
Update utxo.j2

### DIFF
--- a/autobuild/templates/utxo.j2
+++ b/autobuild/templates/utxo.j2
@@ -2,7 +2,7 @@
 
   utxo-plugin-{{ chain.name.upper() }}:
     image: {{ utxo_plugin_image }}
-    restart: unless-stopped 
+    restart: 'no' 
     environment:
       PLUGIN_COIN: {{ chain.name.upper() }}
       PLUGIN_PORT: 8000


### PR DESCRIPTION
fix endless restart in case of corrupted container, container won't stop in normal behavior,
need manual intervention to reestablish it.